### PR TITLE
Datadeps handling for algorithm tasks

### DIFF
--- a/data/datadeps_demo/df.graphml
+++ b/data/datadeps_demo/df.graphml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd"><key id="d4" for="node" attr.name="size_average_B" attr.type="double"/>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+<key id="d4" for="node" attr.name="size_average_B" attr.type="double"/>
 <key id="d3" for="node" attr.name="class" attr.type="string"/>
 <key id="d2" for="node" attr.name="node_id" attr.type="string"/>
 <key id="d1" for="node" attr.name="runtime_average_s" attr.type="double"/>

--- a/data/sequencer_demo/another_test_graph.graphml
+++ b/data/sequencer_demo/another_test_graph.graphml
@@ -1,88 +1,106 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-  <key id="key0" for="node" attr.name="class" attr.type="string" />
-  <key id="key1" for="node" attr.name="node_id" attr.type="string" />
-  <key id="key2" for="node" attr.name="type" attr.type="string" />
+  <key id="d0" for="node" attr.name="class" attr.type="string" />
+  <key id="d1" for="node" attr.name="node_id" attr.type="string" />
+  <key id="d2" for="node" attr.name="type" attr.type="string" />
+  <key id="d3" for="node" attr.name="runtime_average_s" attr.type="double" />
+  <key id="d4" for="node" attr.name="size_kb" attr.type="double" />
   <graph id="G" edgedefault="directed" parse.nodeids="free" parse.edgeids="canonical" parse.order="nodesfirst">
     <node id="n0">
-      <data key="key0">MicroProducer</data>
-      <data key="key1">ProducerA</data>
-      <data key="key2">Algorithm</data>
+      <data key="d0">MicroProducer</data>
+      <data key="d1">ProducerA</data>
+      <data key="d2">Algorithm</data>
+      <data key="d3">9.3027e-05</data>
     </node>
     <node id="n1">
-      <data key="key0"></data>
-      <data key="key1">A</data>
-      <data key="key2">DataObject</data>
+      <data key="d0"></data>
+      <data key="d1">A</data>
+      <data key="d2">DataObject</data>
+      <data key="d4">8.0</data>
     </node>
     <node id="n2">
-      <data key="key0">MicroTransformer</data>
-      <data key="key1">TransformerB</data>
-      <data key="key2">Algorithm</data>
+      <data key="d0">MicroTransformer</data>
+      <data key="d1">TransformerB</data>
+      <data key="d2">Algorithm</data>
+      <data key="d3">4.2463e-05</data>
     </node>
     <node id="n3">
-      <data key="key0"></data>
-      <data key="key1">C</data>
-      <data key="key2">DataObject</data>
+      <data key="d0"></data>
+      <data key="d1">C</data>
+      <data key="d2">DataObject</data>
+      <data key="d4">8.0</data>
     </node>
     <node id="n4">
-      <data key="key0">MicroTransformer</data>
-      <data key="key1">TransformerD</data>
-      <data key="key2">Algorithm</data>
+      <data key="d0">MicroTransformer</data>
+      <data key="d1">TransformerD</data>
+      <data key="d2">Algorithm</data>
+      <data key="d3">8.241000000000001e-06</data>
     </node>
     <node id="n5">
-      <data key="key0"></data>
-      <data key="key1">E</data>
-      <data key="key2">DataObject</data>
+      <data key="d0"></data>
+      <data key="d1">E</data>
+      <data key="d2">DataObject</data>
+      <data key="d4">8.0</data>
     </node>
     <node id="n6">
-      <data key="key0">MicroTransformer</data>
-      <data key="key1">TransformerF</data>
-      <data key="key2">Algorithm</data>
+      <data key="d0">MicroTransformer</data>
+      <data key="d1">TransformerF</data>
+      <data key="d2">Algorithm</data>
+      <data key="d3">7.264e-06</data>
     </node>
     <node id="n7">
-      <data key="key0"></data>
-      <data key="key1">G</data>
-      <data key="key2">DataObject</data>
+      <data key="d0"></data>
+      <data key="d1">G</data>
+      <data key="d2">DataObject</data>
+      <data key="d4">8.0</data>
     </node>
     <node id="n8">
-      <data key="key0">MicroTransformer</data>
-      <data key="key1">TransformerH</data>
-      <data key="key2">Algorithm</data>
+      <data key="d0">MicroTransformer</data>
+      <data key="d1">TransformerH</data>
+      <data key="d2">Algorithm</data>
+      <data key="d3">6.705e-06</data>
     </node>
     <node id="n9">
-      <data key="key0"></data>
-      <data key="key1">I</data>
-      <data key="key2">DataObject</data>
+      <data key="d0"></data>
+      <data key="d1">I</data>
+      <data key="d2">DataObject</data>
+      <data key="d4">8.0</data>
     </node>
     <node id="n10">
-      <data key="key0">MicroTransformer</data>
-      <data key="key1">TransformerJ</data>
-      <data key="key2">Algorithm</data>
+      <data key="d0">MicroTransformer</data>
+      <data key="d1">TransformerJ</data>
+      <data key="d2">Algorithm</data>
+      <data key="d3">8.59e-06</data>
     </node>
     <node id="n11">
-      <data key="key0"></data>
-      <data key="key1">K</data>
-      <data key="key2">DataObject</data>
+      <data key="d0"></data>
+      <data key="d1">K</data>
+      <data key="d2">DataObject</data>
+      <data key="d4">8.0</data>
     </node>
     <node id="n12">
-      <data key="key0">MicroTransformer</data>
-      <data key="key1">TransformerL</data>
-      <data key="key2">Algorithm</data>
+      <data key="d0">MicroTransformer</data>
+      <data key="d1">TransformerL</data>
+      <data key="d2">Algorithm</data>
+      <data key="d3">8.94e-06</data>
     </node>
     <node id="n13">
-      <data key="key0"></data>
-      <data key="key1">M</data>
-      <data key="key2">DataObject</data>
+      <data key="d0"></data>
+      <data key="d1">M</data>
+      <data key="d2">DataObject</data>
+      <data key="d4">8.0</data>
     </node>
     <node id="n14">
-      <data key="key0">MicroTransformer</data>
-      <data key="key1">TransformerN</data>
-      <data key="key2">Algorithm</data>
+      <data key="d0">MicroTransformer</data>
+      <data key="d1">TransformerN</data>
+      <data key="d2">Algorithm</data>
+      <data key="d3">8.94e-06</data>
     </node>
     <node id="n15">
-      <data key="key0"></data>
-      <data key="key1">O</data>
-      <data key="key2">DataObject</data>
+      <data key="d0"></data>
+      <data key="d1">O</data>
+      <data key="d2">DataObject</data>
+      <data key="d4">8.0</data>
     </node>
     
     <edge id="e0" source="n0" target="n1">

--- a/data/sequencer_demo/another_test_graph.graphml
+++ b/data/sequencer_demo/another_test_graph.graphml
@@ -4,7 +4,7 @@
   <key id="d1" for="node" attr.name="node_id" attr.type="string" />
   <key id="d2" for="node" attr.name="type" attr.type="string" />
   <key id="d3" for="node" attr.name="runtime_average_s" attr.type="double" />
-  <key id="d4" for="node" attr.name="size_kb" attr.type="double" />
+  <key id="d4" for="node" attr.name="size_average_B" attr.type="double" />
   <graph id="G" edgedefault="directed" parse.nodeids="free" parse.edgeids="canonical" parse.order="nodesfirst">
     <node id="n0">
       <data key="d0">MicroProducer</data>

--- a/data/sequencer_demo/df_sequencer_demo.graphml
+++ b/data/sequencer_demo/df_sequencer_demo.graphml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd"><key id="d4" for="node" attr.name="size_average_B" attr.type="double"/>
-<key id="d4" for="node" attr.name="size_kb" attr.type="double"/>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+<key id="d4" for="node" attr.name="size_average_B" attr.type="double"/>
 <key id="d3" for="node" attr.name="class" attr.type="string"/>
 <key id="d2" for="node" attr.name="node_id" attr.type="string"/>
 <key id="d1" for="node" attr.name="runtime_average_s" attr.type="double"/>

--- a/data/sequencer_demo/df_sequencer_demo.graphml
+++ b/data/sequencer_demo/df_sequencer_demo.graphml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd"><key id="d4" for="node" attr.name="size_average_B" attr.type="double"/>
+<key id="d4" for="node" attr.name="size_kb" attr.type="double"/>
 <key id="d3" for="node" attr.name="class" attr.type="string"/>
 <key id="d2" for="node" attr.name="node_id" attr.type="string"/>
 <key id="d1" for="node" attr.name="runtime_average_s" attr.type="double"/>

--- a/examples/schedule.jl
+++ b/examples/schedule.jl
@@ -1,6 +1,6 @@
 using Distributed
 
-## doesn't work with datadeps!
+## doesn't work with datadeps! threads work though
 # if abspath(PROGRAM_FILE) == @__FILE__
 #     new_procs = addprocs(12) # Set the number of workers
 # end
@@ -69,7 +69,7 @@ function main(graphs_map)
     #
     # OR 
     #
-    # configure_webdash_multievent()
+    # FrameworkDemo.configure_webdash_multievent()
 
     @time execution(graphs_map)
 

--- a/examples/schedule.jl
+++ b/examples/schedule.jl
@@ -1,15 +1,16 @@
 using Distributed
 
-if abspath(PROGRAM_FILE) == @__FILE__
-    new_procs = addprocs(12) # Set the number of workers
-end
+## doesn't work with datadeps!
+# if abspath(PROGRAM_FILE) == @__FILE__
+#     new_procs = addprocs(12) # Set the number of workers
+# end
+##
 
 using Dagger
 using Graphs
 using MetaGraphs
 using FrameworkDemo
 using FrameworkDemo.ModGraphVizSimple # This is a workaround to make visualization work until the bugs are fixed in the package.
-
 
 # Defining constants
 output_dir = "results"
@@ -46,7 +47,8 @@ function execution(graphs_map)
     results = []
     for (g_name, g) in graphs
         g_map = Dict{Int, Any}()
-        for vertex_id in Graphs.vertices(g)
+        data_vertices = MetaGraphs.filter_vertices(g, :type, "DataObject")
+        for vertex_id in data_vertices
             future = get_prop(g, vertex_id, :res_data)
             g_map[vertex_id] = fetch(future)
         end

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -5,7 +5,7 @@ using MetaGraphs
 
 mutable struct DataObject
     data
-    size::Int
+    size::Float64
 end
 
 function populate_data_object!(object::DataObject, data)
@@ -25,7 +25,8 @@ function _algorithm(graph::MetaDiGraph, vertex_id::Int)
         println("Gaudi algorithm for vertex $vertex_id !")
 
         for output in outputs
-            populate_data_object!(output, ' '^output.size)
+            bytes = round(Int, output.size * 1e3)
+            populate_data_object!(output, ' '^bytes)
         end
 
         sleep(runtime)
@@ -131,7 +132,7 @@ function schedule_graph(G::MetaDiGraph)
     sorted_vertices = MetaGraphs.topological_sort(G)
 
     for data_id in data_vertices
-        size = get_prop(G, data_id, :size)
+        size = get_prop(G, data_id, :size_kb)
         set_prop!(G, data_id, :res_data, DataObject(nothing, size))
     end
 

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -35,9 +35,6 @@ function make_algorithm(graph::MetaDiGraph, vertex_id::Int)
     return algorithm
 end
 
-AVAILABLE_TRANSFORMS = Dict{String, Function}(
-    "Algorithm" => _algorithm,
-)
 
 function get_transform(graph::MetaDiGraph, vertex_id::Int)
     type = get_prop(graph, vertex_id, :type)

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -132,7 +132,7 @@ function schedule_graph(G::MetaDiGraph)
     sorted_vertices = MetaGraphs.topological_sort(G)
 
     for data_id in data_vertices
-        size = get_prop(G, data_id, :size_kb)
+        size = get_prop(G, data_id, :size_average_B)
         set_prop!(G, data_id, :res_data, DataObject(nothing, size))
     end
 

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -18,7 +18,7 @@ function populate_data_object!(object::DataObject, data)
 end
 
 # Algorithms
-function _algorithm(graph::MetaDiGraph, vertex_id::Int)
+function make_algorithm(graph::MetaDiGraph, vertex_id::Int)
     runtime = get_prop(graph, vertex_id, :runtime_average_s)
 
     function algorithm(inputs, outputs)


### PR DESCRIPTION
BEGINRELEASENOTES
- Algorithm functions now created to be aware of the graph state at schedule-time
- Data objects no longer scheduled
- Outputs are now passed as mutable DataObject structs via `Dagger.spawn_datadeps()`
- Test graphml files now have size and runtime properties
- DataObject size allocated according to graphml specification
- Length of `sleep` in algorithm now dependent on graph properties

ENDRELEASENOTES
