### PR TITLE
Configure algorithm runtime, don't schedule data object nodes as algortihms

### DIFF
--- a/data/datadeps_demo/df.graphml
+++ b/data/datadeps_demo/df.graphml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd"><key id="d4" for="node" attr.name="size_average_B" attr.type="double"/>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+<key id="d4" for="node" attr.name="size_average_B" attr.type="double"/>
 <key id="d3" for="node" attr.name="class" attr.type="string"/>
 <key id="d2" for="node" attr.name="node_id" attr.type="string"/>
 <key id="d1" for="node" attr.name="runtime_average_s" attr.type="double"/>

--- a/data/sequencer_demo/another_test_graph.graphml
+++ b/data/sequencer_demo/another_test_graph.graphml
@@ -1,88 +1,106 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-  <key id="key0" for="node" attr.name="class" attr.type="string" />
-  <key id="key1" for="node" attr.name="node_id" attr.type="string" />
-  <key id="key2" for="node" attr.name="type" attr.type="string" />
+  <key id="d0" for="node" attr.name="class" attr.type="string" />
+  <key id="d1" for="node" attr.name="node_id" attr.type="string" />
+  <key id="d2" for="node" attr.name="type" attr.type="string" />
+  <key id="d3" for="node" attr.name="runtime_average_s" attr.type="double" />
+  <key id="d4" for="node" attr.name="size_kb" attr.type="double" />
   <graph id="G" edgedefault="directed" parse.nodeids="free" parse.edgeids="canonical" parse.order="nodesfirst">
     <node id="n0">
-      <data key="key0">MicroProducer</data>
-      <data key="key1">ProducerA</data>
-      <data key="key2">Algorithm</data>
+      <data key="d0">MicroProducer</data>
+      <data key="d1">ProducerA</data>
+      <data key="d2">Algorithm</data>
+      <data key="d3">9.3027e-05</data>
     </node>
     <node id="n1">
-      <data key="key0"></data>
-      <data key="key1">A</data>
-      <data key="key2">DataObject</data>
+      <data key="d0"></data>
+      <data key="d1">A</data>
+      <data key="d2">DataObject</data>
+      <data key="d4">8.0</data>
     </node>
     <node id="n2">
-      <data key="key0">MicroTransformer</data>
-      <data key="key1">TransformerB</data>
-      <data key="key2">Algorithm</data>
+      <data key="d0">MicroTransformer</data>
+      <data key="d1">TransformerB</data>
+      <data key="d2">Algorithm</data>
+      <data key="d3">4.2463e-05</data>
     </node>
     <node id="n3">
-      <data key="key0"></data>
-      <data key="key1">C</data>
-      <data key="key2">DataObject</data>
+      <data key="d0"></data>
+      <data key="d1">C</data>
+      <data key="d2">DataObject</data>
+      <data key="d4">8.0</data>
     </node>
     <node id="n4">
-      <data key="key0">MicroTransformer</data>
-      <data key="key1">TransformerD</data>
-      <data key="key2">Algorithm</data>
+      <data key="d0">MicroTransformer</data>
+      <data key="d1">TransformerD</data>
+      <data key="d2">Algorithm</data>
+      <data key="d3">8.241000000000001e-06</data>
     </node>
     <node id="n5">
-      <data key="key0"></data>
-      <data key="key1">E</data>
-      <data key="key2">DataObject</data>
+      <data key="d0"></data>
+      <data key="d1">E</data>
+      <data key="d2">DataObject</data>
+      <data key="d4">8.0</data>
     </node>
     <node id="n6">
-      <data key="key0">MicroTransformer</data>
-      <data key="key1">TransformerF</data>
-      <data key="key2">Algorithm</data>
+      <data key="d0">MicroTransformer</data>
+      <data key="d1">TransformerF</data>
+      <data key="d2">Algorithm</data>
+      <data key="d3">7.264e-06</data>
     </node>
     <node id="n7">
-      <data key="key0"></data>
-      <data key="key1">G</data>
-      <data key="key2">DataObject</data>
+      <data key="d0"></data>
+      <data key="d1">G</data>
+      <data key="d2">DataObject</data>
+      <data key="d4">8.0</data>
     </node>
     <node id="n8">
-      <data key="key0">MicroTransformer</data>
-      <data key="key1">TransformerH</data>
-      <data key="key2">Algorithm</data>
+      <data key="d0">MicroTransformer</data>
+      <data key="d1">TransformerH</data>
+      <data key="d2">Algorithm</data>
+      <data key="d3">6.705e-06</data>
     </node>
     <node id="n9">
-      <data key="key0"></data>
-      <data key="key1">I</data>
-      <data key="key2">DataObject</data>
+      <data key="d0"></data>
+      <data key="d1">I</data>
+      <data key="d2">DataObject</data>
+      <data key="d4">8.0</data>
     </node>
     <node id="n10">
-      <data key="key0">MicroTransformer</data>
-      <data key="key1">TransformerJ</data>
-      <data key="key2">Algorithm</data>
+      <data key="d0">MicroTransformer</data>
+      <data key="d1">TransformerJ</data>
+      <data key="d2">Algorithm</data>
+      <data key="d3">8.59e-06</data>
     </node>
     <node id="n11">
-      <data key="key0"></data>
-      <data key="key1">K</data>
-      <data key="key2">DataObject</data>
+      <data key="d0"></data>
+      <data key="d1">K</data>
+      <data key="d2">DataObject</data>
+      <data key="d4">8.0</data>
     </node>
     <node id="n12">
-      <data key="key0">MicroTransformer</data>
-      <data key="key1">TransformerL</data>
-      <data key="key2">Algorithm</data>
+      <data key="d0">MicroTransformer</data>
+      <data key="d1">TransformerL</data>
+      <data key="d2">Algorithm</data>
+      <data key="d3">8.94e-06</data>
     </node>
     <node id="n13">
-      <data key="key0"></data>
-      <data key="key1">M</data>
-      <data key="key2">DataObject</data>
+      <data key="d0"></data>
+      <data key="d1">M</data>
+      <data key="d2">DataObject</data>
+      <data key="d4">8.0</data>
     </node>
     <node id="n14">
-      <data key="key0">MicroTransformer</data>
-      <data key="key1">TransformerN</data>
-      <data key="key2">Algorithm</data>
+      <data key="d0">MicroTransformer</data>
+      <data key="d1">TransformerN</data>
+      <data key="d2">Algorithm</data>
+      <data key="d3">8.94e-06</data>
     </node>
     <node id="n15">
-      <data key="key0"></data>
-      <data key="key1">O</data>
-      <data key="key2">DataObject</data>
+      <data key="d0"></data>
+      <data key="d1">O</data>
+      <data key="d2">DataObject</data>
+      <data key="d4">8.0</data>
     </node>
     
     <edge id="e0" source="n0" target="n1">

--- a/data/sequencer_demo/another_test_graph.graphml
+++ b/data/sequencer_demo/another_test_graph.graphml
@@ -4,7 +4,7 @@
   <key id="d1" for="node" attr.name="node_id" attr.type="string" />
   <key id="d2" for="node" attr.name="type" attr.type="string" />
   <key id="d3" for="node" attr.name="runtime_average_s" attr.type="double" />
-  <key id="d4" for="node" attr.name="size_kb" attr.type="double" />
+  <key id="d4" for="node" attr.name="size_average_B" attr.type="double" />
   <graph id="G" edgedefault="directed" parse.nodeids="free" parse.edgeids="canonical" parse.order="nodesfirst">
     <node id="n0">
       <data key="d0">MicroProducer</data>

--- a/data/sequencer_demo/df_sequencer_demo.graphml
+++ b/data/sequencer_demo/df_sequencer_demo.graphml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd"><key id="d4" for="node" attr.name="size_average_B" attr.type="double"/>
-<key id="d4" for="node" attr.name="size_kb" attr.type="double"/>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+<key id="d4" for="node" attr.name="size_average_B" attr.type="double"/>
 <key id="d3" for="node" attr.name="class" attr.type="string"/>
 <key id="d2" for="node" attr.name="node_id" attr.type="string"/>
 <key id="d1" for="node" attr.name="runtime_average_s" attr.type="double"/>

--- a/data/sequencer_demo/df_sequencer_demo.graphml
+++ b/data/sequencer_demo/df_sequencer_demo.graphml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd"><key id="d4" for="node" attr.name="size_average_B" attr.type="double"/>
+<key id="d4" for="node" attr.name="size_kb" attr.type="double"/>
 <key id="d3" for="node" attr.name="class" attr.type="string"/>
 <key id="d2" for="node" attr.name="node_id" attr.type="string"/>
 <key id="d1" for="node" attr.name="runtime_average_s" attr.type="double"/>

--- a/examples/schedule.jl
+++ b/examples/schedule.jl
@@ -46,7 +46,8 @@ function execution(graphs_map)
     results = []
     for (g_name, g) in graphs
         g_map = Dict{Int, Any}()
-        for vertex_id in Graphs.vertices(g)
+        data_vertices = MetaGraphs.filter_vertices(g, :type, "DataObject")
+        for vertex_id in data_vertices
             future = get_prop(g, vertex_id, :res_data)
             g_map[vertex_id] = fetch(future)
         end
@@ -64,10 +65,6 @@ end
 
 function main(graphs_map)
     FrameworkDemo.configure_LocalEventLog()
-    #
-    # OR 
-    #
-    # configure_webdash_multievent()
 
     @time execution(graphs_map)
 

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -44,42 +44,6 @@ function parse_graphs(graphs_map::Dict, output_graph_path::String, output_graph_
     return graphs
 end
 
-# Function to get the map of incoming edges to a vertex (i.e. the sources of the incoming edges)
-function get_ine_map(G)
-    incoming_edges_sources_map = Dict{eltype(G), Vector{eltype(G)}}()
-
-    for edge in Graphs.edges(G)
-        src_vertex = src(edge)
-        dest_vertex = dst(edge)
-
-        if haskey(incoming_edges_sources_map, dest_vertex)
-            push!(incoming_edges_sources_map[dest_vertex], src_vertex)
-        else
-            incoming_edges_sources_map[dest_vertex] = [src_vertex]
-        end
-    end
-
-    return incoming_edges_sources_map
-end
-
-# Function to get the map of outgoing edges from a vertex (i.e. the destinations of the outgoing edges)
-function get_oute_map(G)
-    outgoing_edges_destinations_map = Dict{eltype(G), Vector{eltype(G)}}()
-
-    for edge in Graphs.edges(G)
-        src_vertex = src(edge)
-        dest_vertex = dst(edge)
-
-        if haskey(outgoing_edges_destinations_map, src_vertex)
-            push!(outgoing_edges_destinations_map[src_vertex], dest_vertex)
-        else
-            outgoing_edges_destinations_map[src_vertex] = [dest_vertex]
-        end
-    end
-
-    return outgoing_edges_destinations_map
-end
-
 function get_promises(graph::MetaDiGraph, vertices::Vector)
     return [get_prop(graph, v, :res_data) for v in vertices]
 end

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -54,7 +54,7 @@ function is_terminating_alg(graph::AbstractGraph, vertex_id::Int)
     all(is_terminating, successor_dataobjects)
 end
 
-function schedule_algorithm!(graph::MetaDiGraph, vertex_id::Int)
+function schedule_algorithm(graph::MetaDiGraph, vertex_id::Int)
     incoming_data = get_promises(graph, inneighbors(graph, vertex_id))
     algorithm = MockupAlgorithm(graph, vertex_id)
     Dagger.@spawn algorithm(incoming_data...)
@@ -67,7 +67,7 @@ function schedule_graph(graph::MetaDiGraph)
     terminating_results = []
 
     for vertex_id in intersect(sorted_vertices, alg_vertices)
-        res = schedule_algorithm!(graph, vertex_id)
+        res = schedule_algorithm(graph, vertex_id)
         set_prop!(graph, vertex_id, :res_data, res)
         for v in outneighbors(graph, vertex_id)
             set_prop!(graph, v, :res_data, res)
@@ -80,9 +80,9 @@ function schedule_graph(graph::MetaDiGraph)
 end
 
 function schedule_graph_with_notify(graph::MetaDiGraph,
-        notifications::RemoteChannel,
-        graph_name::String,
-        graph_id::Int)
+    notifications::RemoteChannel,
+    graph_name::String,
+    graph_id::Int)
     terminating_results = schedule_graph(graph)
 
     Dagger.@spawn notify_graph_finalization(notifications, graph_name, graph_id, terminating_results...)

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -16,14 +16,9 @@ struct MockupAlgorithm
 end
 
 function (alg::MockupAlgorithm)(args...)
-    # struct not fully used yet, but it will be!
+    println("Executing $(alg.name)")
 
-    function execute!(alg::MockupAlgorithm, _)
-        println("Executing $(alg.name)")
-        return alg.name
-    end
-
-    execute!(alg, args)
+    return alg.name
 end
 
 function notify_graph_finalization(notifications::RemoteChannel, graph_name::String, graph_id::Int, final_vertices_promises...)

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -3,16 +3,27 @@ using Distributed
 using MetaGraphs
 
 # Algorithms
-function mock_Gaudi_algorithm(graph_name, graph_id, vertex_id, data...)
-    println("Graph: $graph_name, Gaudi algorithm for vertex $vertex_id !")
-    sleep(1)
-    return vertex_id
+struct MockupAlgorithm
+    name::String
+    runtime::Float64
+    input_length::UInt
+    MockupAlgorithm(graph::MetaDiGraph, vertex_id::Int) = begin
+        runtime = get_prop(graph, vertex_id, :runtime_average_s)
+        name = get_prop(graph, vertex_id, :node_id)
+        inputs = length(inneighbors(graph, vertex_id))
+        new(name, runtime, inputs)
+    end
 end
 
-function dataobject_algorithm(graph_name, graph_id, vertex_id, data...)
-    println("Graph: $graph_name, Dataobject algorithm for vertex $vertex_id !")
-    sleep(0.1)
-    return vertex_id
+function (alg::MockupAlgorithm)(args...)
+    # struct not fully used yet, but it will be!
+
+    function execute!(alg::MockupAlgorithm, _)
+        println("Executing $(alg.name)")
+        return alg.name
+    end
+
+    execute!(alg, args)
 end
 
 function notify_graph_finalization(notifications::RemoteChannel, graph_name::String, graph_id::Int, final_vertices_promises...)
@@ -28,7 +39,7 @@ function parse_graphs(graphs_map::Dict, output_graph_path::String, output_graph_
         parsed_graph_dot = timestamp_string("$output_graph_path$graph_name") * ".dot"
         parsed_graph_image = timestamp_string("$output_graph_image_path$graph_name") * ".png"
         G = parse_graphml([graph_path])
-        
+
         open(parsed_graph_dot, "w") do f
             MetaGraphs.savedot(f, G)
         end
@@ -45,7 +56,7 @@ function get_ine_map(G)
     for edge in Graphs.edges(G)
         src_vertex = src(edge)
         dest_vertex = dst(edge)
-        
+
         if haskey(incoming_edges_sources_map, dest_vertex)
             push!(incoming_edges_sources_map[dest_vertex], src_vertex)
         else
@@ -63,14 +74,14 @@ function get_oute_map(G)
     for edge in Graphs.edges(G)
         src_vertex = src(edge)
         dest_vertex = dst(edge)
-        
+
         if haskey(outgoing_edges_destinations_map, src_vertex)
             push!(outgoing_edges_destinations_map[src_vertex], dest_vertex)
         else
             outgoing_edges_destinations_map[src_vertex] = [dest_vertex]
         end
     end
-    
+
     return outgoing_edges_destinations_map
 end
 
@@ -82,33 +93,32 @@ function get_vertices_promises(vertices::Vector, G::MetaDiGraph)
     return promises
 end
 
-function get_deps_promises(vertex_id, map, G)
-    incoming_data = []
-    if haskey(map, vertex_id)
-        for src in map[vertex_id]
-            push!(incoming_data, get_prop(G, src, :res_data))
-        end
-    end
-    return incoming_data
+function get_in_promises(graph::MetaDiGraph, vertex_id::Int)
+    return [get_prop(graph, src, :res_data) for src in inneighbors(graph, vertex_id)]
+end
+
+function schedule_algorithm!(graph::MetaDiGraph, vertex_id::Int)
+    incoming_data = get_in_promises(graph, vertex_id)
+    algorithm = MockupAlgorithm(graph, vertex_id)
+    Dagger.@spawn algorithm(incoming_data...)
 end
 
 function schedule_graph(G::MetaDiGraph)
-    inc_e_src_map = get_ine_map(G)
+    alg_vertices = MetaGraphs.filter_vertices(G, :type, "Algorithm")
+    sorted_vertices = MetaGraphs.topological_sort(G)
 
-    for vertex_id in MetaGraphs.topological_sort(G)
-        incoming_data = get_deps_promises(vertex_id, inc_e_src_map, G)
-        set_prop!(G, vertex_id, :res_data, Dagger.@spawn AVAILABLE_TRANSFORMS[get_prop(G, vertex_id, :type)](name, graph_id, vertex_id, incoming_data...))
+    for vertex_id in intersect(sorted_vertices, alg_vertices)
+        res = schedule_algorithm!(G, vertex_id)
+        for v in outneighbors(G, vertex_id)
+            set_prop!(G, v, :res_data, res)
+        end
     end
 end
 
 function schedule_graph_with_notify(G::MetaDiGraph, notifications::RemoteChannel, graph_name::String, graph_id::Int)
-    final_vertices = []
-    inc_e_src_map = get_ine_map(G)
+    schedule_graph(G::MetaDiGraph)
 
-    for vertex_id in MetaGraphs.topological_sort(G)
-        incoming_data = get_deps_promises(vertex_id, inc_e_src_map, G)
-        set_prop!(G, vertex_id, :res_data, Dagger.@spawn AVAILABLE_TRANSFORMS[get_prop(G, vertex_id, :type)](graph_name, graph_id, vertex_id, incoming_data...))
-    end
+    final_vertices = []
 
     out_e_src_map = get_oute_map(G)
     for vertex_id in MetaGraphs.vertices(G)
@@ -118,12 +128,10 @@ function schedule_graph_with_notify(G::MetaDiGraph, notifications::RemoteChannel
     end
 
     for vertex_id in keys(out_e_src_map)
-        if out_e_src_map[vertex_id] == [] # TODO: a native method to check for emptiness should exist
+        if isempty(out_e_src_map[vertex_id])
             push!(final_vertices, vertex_id)
         end
     end
 
     Dagger.@spawn notify_graph_finalization(notifications, graph_name, graph_id, get_vertices_promises(final_vertices, G)...)
 end
-
-AVAILABLE_TRANSFORMS = Dict{String, Function}("Algorithm" => mock_Gaudi_algorithm, "DataObject" => dataobject_algorithm)


### PR DESCRIPTION
BEGINRELEASENOTES
- Algorithms now handled as a callable struct containing graph information
- Data objects no longer scheduled as tasks

Struct allows algorithm to access information about its vertex, including average runtime and size.
Ideas taken from @m-fila in #19.

ENDRELEASENOTES
