### PR TITLE
Fix data paths in tests

### DIFF
--- a/examples/parsing_graphs.jl
+++ b/examples/parsing_graphs.jl
@@ -3,7 +3,7 @@
 using FrameworkDemo
 
 function main()
-    G = FrameworkDemo.parse_graphml(["./data/demo/sequencer/df.graphml"])
+    G = FrameworkDemo.parse_graphml("./data/demo/sequencer/df.graphml")
     G_copy = deepcopy(G)
     FrameworkDemo.show_graph(G_copy)
 end

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -2,9 +2,8 @@ using Graphs
 using MetaGraphs
 include("../deps/GraphMLReader.jl/src/GraphMLReader.jl")
 
-function parse_graphml(path)
-    file_path = joinpath(path...)
-    G = GraphMLReader.loadgraphml(file_path, "G")
+function parse_graphml(filename::String)::MetaDiGraph
+    GraphMLReader.loadgraphml(filename, "G")
 end
 
 function show_graph(G)

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -33,7 +33,7 @@ function parse_graphs(graphs_map::Dict, output_graph_path::String, output_graph_
     for (graph_name, graph_path) in graphs_map
         parsed_graph_dot = timestamp_string("$output_graph_path$graph_name") * ".dot"
         parsed_graph_image = timestamp_string("$output_graph_image_path$graph_name") * ".png"
-        G = parse_graphml([graph_path])
+        G = parse_graphml(graph_path)
 
         open(parsed_graph_dot, "w") do f
             MetaGraphs.savedot(f, G)

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -3,7 +3,7 @@ using Graphs
 using MetaGraphs
 
 @testset "Parsing" begin
-    graph = FrameworkDemo.parse_graphml(["../data/demo/sequencer/df.graphml"])
+    graph = FrameworkDemo.parse_graphml("../data/demo/sequencer/df.graphml")
     set_indexing_prop!(graph, :original_id)
 
     # Test the general structure of the graph

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -3,7 +3,8 @@ using Graphs
 using MetaGraphs
 
 @testset "Parsing" begin
-    graph = FrameworkDemo.parse_graphml("../data/demo/sequencer/df.graphml")
+    path = joinpath(pkgdir(FrameworkDemo), "data/demo/sequencer/df.graphml")
+    graph = FrameworkDemo.parse_graphml(path)
     set_indexing_prop!(graph, :original_id)
 
     # Test the general structure of the graph

--- a/test/scheduling.jl
+++ b/test/scheduling.jl
@@ -36,7 +36,7 @@ end
 
 
 @testset verbose = true "Scheduling" begin
-    graph = FrameworkDemo.parse_graphml(["../data/demo/datadeps/df.graphml"])
+    graph = FrameworkDemo.parse_graphml("../data/demo/datadeps/df.graphml")
     ilength(x) = sum(_ -> 1, x) # no standard length for MetaGraphs.filter_vertices iterator
     algorithms_count = ilength(MetaGraphs.filter_vertices(graph, :type, "Algorithm"))
     set_indexing_prop!(graph, :node_id)

--- a/test/scheduling.jl
+++ b/test/scheduling.jl
@@ -36,7 +36,8 @@ end
 
 
 @testset verbose = true "Scheduling" begin
-    graph = FrameworkDemo.parse_graphml("../data/demo/datadeps/df.graphml")
+    path = joinpath(pkgdir(FrameworkDemo), "data/demo/datadeps/df.graphml")
+    graph = FrameworkDemo.parse_graphml(path)
     ilength(x) = sum(_ -> 1, x) # no standard length for MetaGraphs.filter_vertices iterator
     algorithms_count = ilength(MetaGraphs.filter_vertices(graph, :type, "Algorithm"))
     set_indexing_prop!(graph, :node_id)


### PR DESCRIPTION
BEGINRELEASENOTES
- Fixed paths to workflow data in the tests
- `parse_graphml` accepts singular objects instead of vectors

ENDRELEASENOTES

The relatives paths to workflow data were broken when running directly`test/runtests.jl`
Now the tests can be run both directly from `test/runtests.jl` and `Pkg.test`
