### PR TITLE
Fix scheduling algorithms without runtime property

### DIFF
--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -8,12 +8,19 @@ struct MockupAlgorithm
     runtime::Float64
     input_length::UInt
     MockupAlgorithm(graph::MetaDiGraph, vertex_id::Int) = begin
-        runtime = get_prop(graph, vertex_id, :runtime_average_s)
         name = get_prop(graph, vertex_id, :node_id)
+        if has_prop(graph, vertex_id, :runtime_average_s)
+           runtime = get_prop(graph, vertex_id, :runtime_average_s)
+        else
+            runtime = alg_default_runtime_s
+            @warn "Runtime not provided for $name algorithm. Using default value $runtime"
+        end
         inputs = length(inneighbors(graph, vertex_id))
         new(name, runtime, inputs)
     end
 end
+
+alg_default_runtime_s::Float64 = 0
 
 function (alg::MockupAlgorithm)(args...)
     println("Executing $(alg.name)")


### PR DESCRIPTION
BEGINRELEASENOTES
- Fixed scheduling of algorithms with missing runtime property. A warning is displayed and the default value 0 is used

ENDRELEASENOTES

Scheduling ATLAS/q449 got broken in [#21](https://github.com/key4hep/key4hep-julia-fwk/pull/21) because some of the algorithm vertices don't specify a runtime property. After inspection, it seems that they were never executed in the test job hence the values were missing.
Adding handling missing runtime information should be more flexible  (default for now, could be changed to average later) than putting a  default value in the graphml