### PR TITLE
allow skipping cpu crunching

### DIFF
--- a/bin/schedule.jl
+++ b/bin/schedule.jl
@@ -27,6 +27,11 @@ function parse_args()
         "--dot-trace"
         help = "Output graphviz dot file for execution logs graph"
         arg_type = String
+
+        "--fast"
+        help = "Execute algorithms immediately skipping algorithm runtime information and crunching"
+        action = :store_true
+
     end
 
     return ArgParse.parse_args(s)
@@ -35,16 +40,21 @@ end
 function main()
     args = parse_args()
 
-    event_count = args["event-count"]
-    max_concurrent = args["max-concurrent"]
-
     if !isnothing(args["dot-trace"])
         @info "Enabled logging"
         FrameworkDemo.configure_LocalEventLog()
     end
 
     graph = FrameworkDemo.parse_graphml(args["data-flow"])
-    FrameworkDemo.run_events(graph, event_count, max_concurrent)
+    event_count=args["event-count"]
+    max_concurrent=args["max-concurrent"]
+    fast=args["fast"]
+
+    @time "Pipeline execution" FrameworkDemo.run_events(graph;
+        event_count=event_count,
+        max_concurrent=max_concurrent,
+        fast=fast
+    )
 
     if !isnothing(args["dot-trace"])
         logs = Dagger.fetch_logs!()

--- a/src/cpu_crunching.jl
+++ b/src/cpu_crunching.jl
@@ -29,7 +29,7 @@ function benchmark_prime(n::Int)
     return Δt
 end
 
-function calculate_coefficients()
+function calculate_coefficients()::Vector{Float64}
     n_max = [1000,200_000]
     t_average = benchmark_prime.(n_max)
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,32 @@
+# FrameworkDemo tests
+
+## Usage
+
+Run the tests with:
+
+- Pkg REPL (arguments not supported):
+  ```julia
+  ] test
+  ```
+- Pkg:
+  ```julia
+  import Pkg
+  Pkg.test("FrameworkDemo")
+  # or with arguments
+  Pkg.test("FrameworkDemo"; test_args=<list of args>)
+  ```
+- Manually:
+  ```
+  julia --project test/runtests.jl <list of args>
+  ```
+- REPL:
+  ```julia
+  append!(ARGS, <list of args>)
+  include("test/runtests.jl")
+  ```
+
+## Arguments
+
+The tests support arguments:
+
+- `no-fast` - don't skip algorithm CPU crunching

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using Test
     n_workers = Distributed.nworkers(),
     n_procs = Distributed.nprocs(),
     n_threads = Threads.nthreads(),
+    test_args = repr(ARGS)
 )
 
 @testset verbose = true "FrameworkDemo.jl" begin

--- a/test/scheduling.jl
+++ b/test/scheduling.jl
@@ -41,7 +41,8 @@ end
     ilength(x) = sum(_ -> 1, x) # no standard length for MetaGraphs.filter_vertices iterator
     algorithms_count = ilength(MetaGraphs.filter_vertices(graph, :type, "Algorithm"))
     set_indexing_prop!(graph, :node_id)
-    coefficients = Dagger.@shard FrameworkDemo.calculate_coefficients()
+    is_fast = "no-fast" ∉ ARGS
+    coefficients = FrameworkDemo.calibrate_crunch(;fast=is_fast)
 
     Dagger.enable_logging!(tasknames=true, taskdeps=true)
     _ = Dagger.fetch_logs!() # flush logs


### PR DESCRIPTION
BEGINRELEASENOTES
- Added skipping cpu crunching in algortihms
- Added `--fast` flag to runner that runs the algorithms without crunching
- Added configuring tests with arguments. Tests by default skip crunching
ENDRELEASENOTES

In some scenarios (testing, experimenting) it's cumbersome to wait for the algorithms to finish crunching. A mechanism to skip crunching and return from an algorithm (almost) immediately is introduced

Closing #28 