### PR TITLE
Add tests executing demo workflows

### DIFF
--- a/test/demo_workflows.jl
+++ b/test/demo_workflows.jl
@@ -1,0 +1,23 @@
+using FrameworkDemo
+using Dagger
+
+function run_demo(name::String, coefficients::Union{Dagger.Shard,Nothing})
+    @testset "$name" begin
+        println("Running $(name) workflow demo")
+        path = joinpath(pkgdir(FrameworkDemo), "data/demo/$(name)/df.graphml")
+        graph = FrameworkDemo.parse_graphml(path)
+        @test_nowarn wait.(FrameworkDemo.schedule_graph(graph, coefficients))
+    end
+end
+
+@testset verbose = true "Demo workflows" begin
+    Dagger.disable_logging!()
+    is_fast = "no-fast" ∉ ARGS
+    coefficients = FrameworkDemo.calibrate_crunch(; fast=is_fast)
+    run(name) = run_demo(name, coefficients)
+    run("sequential")
+    run("sequential_terminated")
+    run("parallel")
+    run("datadeps")
+    run("sequencer")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,4 +13,5 @@ using Test
 @testset verbose = true "FrameworkDemo.jl" begin
     include("parsing.jl")
     include("scheduling.jl")
+    include("demo_workflows.jl")
 end


### PR DESCRIPTION
BEGINRELEASENOTES
- Added tests executing demo workflows

ENDRELEASENOTES

Added tests for executing demo workflows that check different topologies and features of graphs (sequential, branching, paths terminated with consumer algorithm or data object, complex data dependencies)
The tests checks only if execution doesn't throw any errors, correctness of results is checked for specific cases in other tests
The tests respect the argument `no-fast` to control whether to run with or without crunching.