### PR TITLE
fix hardcoded channel size resulting in deadlocks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
     "[julia]": {
         "editor.detectIndentation": false,
         "editor.insertSpaces": true,
-        "editor.tabSize": 10,
+        "editor.tabSize": 4,
         "files.insertFinalNewline": true,
         "files.trimFinalNewlines": true,
         "files.trimTrailingWhitespace": true,

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -88,7 +88,7 @@ function run_events(graph::MetaDiGraph;
                     max_concurrent::Int,
                     fast::Bool = false)
     graphs_tasks = Dict{Int, Dagger.DTask}()
-    notifications = RemoteChannel(() -> Channel{Int}(32))
+    notifications = RemoteChannel(() -> Channel{Int}(max_concurrent))
     coefficients = FrameworkDemo.calibrate_crunch(; fast = fast)
 
     for idx in 1:event_count


### PR DESCRIPTION
BEGINRELEASENOTES
- Fixed hardcoded channel size producing deadlocks when scheduling pipelines with concurrency >32

ENDRELEASENOTES
