### PR TITLE
Add tests for pipeline scheduling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,6 @@
 name = "FrameworkDemo"
 uuid = "cfbf7e84-66d2-421e-b147-9edb7a8672d2"
-authors = ["SmalRat <30555080+SmalRat@users.noreply.github.com>",
-           "Mateusz Jakub Fila <mateusz.jakub.fila@cern.ch>",
-           "hegner <benedikt.hegner@cern.ch>",
-           "Josh Ott <joshott16@gmail.com>"]
+authors = ["SmalRat <30555080+SmalRat@users.noreply.github.com>", "Mateusz Jakub Fila <mateusz.jakub.fila@cern.ch>", "hegner <benedikt.hegner@cern.ch>", "Josh Ott <joshott16@gmail.com>"]
 version = "0.1.0"
 
 [deps]
@@ -34,22 +31,24 @@ Colors = "0.12"
 Dagger = "0.18.11"
 DaggerWebDash = "0.1.3"
 DataFrames = "1.6"
+Dates = "1.10"
+Distributed = "1.10"
 EzXML = "1.2"
 FileIO = "1.16"
 GraphViz = "0.2"
 Graphs = "1"
 LightGraphs = "1.3"
+Logging = "1.10"
 MetaGraphs = "0.7"
 Plots = "1.40"
-TimespanLogging = "0.1.0"
-julia = "1.10"
-Dates = "1.10"
-Distributed = "1.10"
 Printf = "1.10"
 Test = "1.10"
+TimespanLogging = "0.1.0"
+julia = "1.10"
 
 [extras]
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Logging", "Test"]

--- a/bin/schedule.jl
+++ b/bin/schedule.jl
@@ -49,7 +49,7 @@ function main()
     max_concurrent = args["max-concurrent"]
     fast = args["fast"]
 
-    @time "Pipeline execution" FrameworkDemo.run_events(graph;
+    @time "Pipeline execution" FrameworkDemo.run_pipeline(graph;
                                                         event_count = event_count,
                                                         max_concurrent = max_concurrent,
                                                         fast = fast)

--- a/bin/schedule.jl
+++ b/bin/schedule.jl
@@ -50,9 +50,9 @@ function main()
     fast = args["fast"]
 
     @time "Pipeline execution" FrameworkDemo.run_pipeline(graph;
-                                                        event_count = event_count,
-                                                        max_concurrent = max_concurrent,
-                                                        fast = fast)
+                                                          event_count = event_count,
+                                                          max_concurrent = max_concurrent,
+                                                          fast = fast)
 
     if !isnothing(args["dot-trace"])
         logs = Dagger.fetch_logs!()

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -71,7 +71,7 @@ end
 function fetch_LocalEventLog()
     ctx = Dagger.Sch.eager_context()
     logs = Dagger.TimespanLogging.get_logs!(ctx.log_sink)
-    # str = Dagger.show_plan() - doesn't work (exist)   
+    # str = Dagger.show_plan() - doesn't work (exist)
     return logs
 end
 
@@ -98,4 +98,12 @@ function save_logs(log_file, logs)
     open(log_file, "w") do io
         write(io, logs)
     end
+end
+
+function dispatch_begin_msg(index)
+    "Dispatcher: scheduled graph $index"
+end
+
+function dispatch_end_msg(index)
+    "Dispatcher: finished graph $index"
 end

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -105,5 +105,8 @@ function run_pipeline(graph::MetaDiGraph;
         @info dispatch_begin_msg(idx)
     end
 
-    values(graphs_tasks) .|> wait
+    for (idx, future) in graphs_tasks
+        wait(future)
+        @info dispatch_end_msg(idx)
+    end
 end

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -83,7 +83,7 @@ function calibrate_crunch(; fast::Bool = false)::Union{Dagger.Shard, Nothing}
     return fast ? nothing : Dagger.@shard calculate_coefficients()
 end
 
-function run_events(graph::MetaDiGraph;
+function run_pipeline(graph::MetaDiGraph;
                     event_count::Int,
                     max_concurrent::Int,
                     fast::Bool = false)
@@ -95,14 +95,14 @@ function run_events(graph::MetaDiGraph;
         while length(graphs_tasks) >= max_concurrent
             finished_graph_id = take!(notifications)
             delete!(graphs_tasks, finished_graph_id)
-            println("Dispatcher: graph finished - graph $finished_graph_id")
+            @info dispatch_end_msg(finished_graph_id)
         end
 
         terminating_results = FrameworkDemo.schedule_graph(graph, coefficients)
         graphs_tasks[idx] = Dagger.@spawn notify_graph_finalization(notifications, idx,
                                                                     terminating_results...)
 
-        println("Dispatcher: scheduled graph $idx")
+        @info dispatch_begin_msg(idx)
     end
 
     values(graphs_tasks) .|> wait

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -84,9 +84,9 @@ function calibrate_crunch(; fast::Bool = false)::Union{Dagger.Shard, Nothing}
 end
 
 function run_pipeline(graph::MetaDiGraph;
-                    event_count::Int,
-                    max_concurrent::Int,
-                    fast::Bool = false)
+                      event_count::Int,
+                      max_concurrent::Int,
+                      fast::Bool = false)
     graphs_tasks = Dict{Int, Dagger.DTask}()
     notifications = RemoteChannel(() -> Channel{Int}(max_concurrent))
     coefficients = FrameworkDemo.calibrate_crunch(; fast = fast)


### PR DESCRIPTION
BEGINRELEASENOTES
- Renamed `run_events` to `run_pipeline`
- Add tests for running a pipeline of graphs

ENDRELEASENOTES

Adding tests verifying all the graphs in a pipeline were run and finished