### PR TITLE
add testing with Aqua.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,6 +24,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 TimespanLogging = "a526e669-04d3-4846-9525-c66122c55f63"
 
 [compat]
+Aqua = "0.8"
 ArgParse = "1.2"
 BenchmarkTools = "1.5"
 Cairo = "1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -47,8 +47,9 @@ TimespanLogging = "0.1.0"
 julia = "1.10"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Logging", "Test"]
+test = ["Aqua", "Logging", "Test"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # FrameworkDemo.jl
 
 [![test](https://github.com/key4hep/key4hep-julia-fwk/actions/workflows/test.yml/badge.svg)](https://github.com/key4hep/key4hep-julia-fwk/actions/workflows/test.yml)
+[![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
 Demonstrator project for HEP data-processing framework in Julia
 

--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -1,0 +1,7 @@
+using Aqua
+using FrameworkDemo
+
+@testset "Aqua.jl" begin
+    Aqua.test_all(FrameworkDemo;
+                  ambiguities = false,)
+end

--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -3,5 +3,10 @@ using FrameworkDemo
 
 @testset "Aqua.jl" begin
     Aqua.test_all(FrameworkDemo;
-                  ambiguities = false,)
+                  ambiguities = false,
+                  stale_deps = (;
+                                ignore = [:ArgParse, # bin/
+                                    :BenchmarkTools, # benchmarks.jl
+                                    :Plots, # benchmarks.jl, Dagger ext
+                                    :DataFrames]))
 end

--- a/test/README.md
+++ b/test/README.md
@@ -22,6 +22,8 @@ Run the tests with:
 - REPL:
   ```julia
   append!(ARGS, <list of args>)
+  import TestEnv
+  TestEnv.activate()
   include("test/runtests.jl")
   ```
 

--- a/test/demo_workflows.jl
+++ b/test/demo_workflows.jl
@@ -10,7 +10,7 @@ function run_demo(name::String, coefficients::Union{Dagger.Shard, Nothing})
     end
 end
 
-@testset verbose=true "Demo workflows" begin
+@testset "Demo workflows" begin
     Dagger.disable_logging!()
     is_fast = "no-fast" ∉ ARGS
     coefficients = FrameworkDemo.calibrate_crunch(; fast = is_fast)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using Test
       test_args=repr(ARGS))
 
 @testset verbose=true "FrameworkDemo.jl" begin
+    include("Aqua.jl")
     include("parsing.jl")
     include("scheduling.jl")
     include("demo_workflows.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,16 @@
 using Distributed
 using Test
 
+if abspath(PROGRAM_FILE) == @__FILE__
+    if !isnothing(Base.find_package("TestEnv"))
+        import TestEnv
+        TestEnv.activate()
+    else
+        @error "Install TestEnv package for running manually"
+        exit(1)
+    end
+end
+
 @info("Execution environment details",
       julia_version=VERSION,
       n_workers=Distributed.nworkers(),
@@ -9,7 +19,9 @@ using Test
       test_args=repr(ARGS))
 
 @testset verbose=true "FrameworkDemo.jl" begin
-    include("Aqua.jl")
+    if "all" ∈ ARGS
+        include("Aqua.jl")
+    end
     include("parsing.jl")
     include("scheduling.jl")
     include("demo_workflows.jl")

--- a/test/scheduling.jl
+++ b/test/scheduling.jl
@@ -35,7 +35,7 @@ function get_alg_deps(logs::Dict)
     return task_deps
 end
 
-@testset verbose=true "Scheduling" begin
+@testset "Scheduling" begin
     path = joinpath(pkgdir(FrameworkDemo), "data/demo/datadeps/df.graphml")
     graph = FrameworkDemo.parse_graphml(path)
     ilength(x) = sum(_ -> 1, x) # no standard length for MetaGraphs.filter_vertices iterator


### PR DESCRIPTION
BEGINRELEASENOTES
- Added testing with Aqua.jl
- `test/runtest.jl` will activate test environment when running manually

ENDRELEASENOTES

Added testing with Aqua.jl. These test are rather slow so are only run when `"all"` is in the `ARGS`. Testing in "CI" will be enabled once #33 is done