### PR TITLE
make tests run standalone

### DIFF
--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -1,5 +1,6 @@
-using Aqua
 using FrameworkDemo
+using Test
+using Aqua
 
 @testset "Aqua.jl" begin
     Aqua.test_all(FrameworkDemo;

--- a/test/README.md
+++ b/test/README.md
@@ -25,6 +25,8 @@ Run the tests with:
   import TestEnv
   TestEnv.activate()
   include("test/runtests.jl")
+  # or run only specific set of tests
+  include("test/parsing.jl")
   ```
 
 ## Arguments
@@ -32,3 +34,4 @@ Run the tests with:
 The tests support arguments:
 
 - `no-fast` - don't skip algorithm CPU crunching
+- `all` - run all the tests including tests that are skipped by default (QA)

--- a/test/demo_workflows.jl
+++ b/test/demo_workflows.jl
@@ -1,4 +1,5 @@
 using FrameworkDemo
+using Test
 using Dagger
 
 function run_demo(name::String, coefficients::Union{Dagger.Shard, Nothing})

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -1,4 +1,5 @@
 using FrameworkDemo
+using Test
 using Graphs
 using MetaGraphs
 

--- a/test/scheduling.jl
+++ b/test/scheduling.jl
@@ -1,4 +1,5 @@
 using FrameworkDemo
+using Test
 using Dagger
 using Graphs
 using MetaGraphs


### PR DESCRIPTION
BEGINRELEASENOTES
- fixed tests to make them run standalone

ENDRELEASENOTES

For convenience a specific test set can be included and run in REPL without including the whole `test/runtests.jl`:
```julia
append!(ARGS, <list of args>)
import TestEnv
TestEnv.activate()
include("test/parsing.jl")
```