### PR TITLE
fix event storage for concurrent execution

### DIFF
--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -52,11 +52,23 @@ end
 
 struct Event
     data_flow::DataFlowGraph
-    store::MetaDiGraph
+    store::Dict{Int, Dagger.DTask}
     event_number::Int
     function Event(data_flow::DataFlowGraph, event_number::Int = 0)
-        new(data_flow, MetaDiGraph(data_flow.graph), event_number)
+        new(data_flow, Dict{Int, Dagger.DTask}(), event_number)
     end
+end
+
+function put_result!(event::Event, index::Int, result::Dagger.DTask)
+    return event.store[index] = result
+end
+
+function get_result(event::Event, index::Int)::Dagger.DTask
+    return event.store[index]
+end
+
+function get_results(event::Event, vertices::Vector{Int})
+    return get_result.(Ref(event), vertices)
 end
 
 function notify_graph_finalization(notifications::RemoteChannel, graph_id::Int,
@@ -64,10 +76,6 @@ function notify_graph_finalization(notifications::RemoteChannel, graph_id::Int,
     println("Graph $graph_id: all tasks in the graph finished!")
     put!(notifications, graph_id)
     println("Graph $graph_id: notified!")
-end
-
-function get_promises(graph::MetaDiGraph, vertices::Vector)
-    return [get_prop(graph, v, :res_data) for v in vertices]
 end
 
 function is_terminating_alg(graph::AbstractGraph, vertex_id::Int)
@@ -78,7 +86,7 @@ end
 
 function schedule_algorithm(event::Event, vertex_id::Int,
                             coefficients::Union{Dagger.Shard, Nothing})
-    incoming_data = get_promises(event.store, inneighbors(event.store, vertex_id))
+    incoming_data = get_results(event, inneighbors(event.data_flow.graph, vertex_id))
     algorithm = get_algorithm(event.data_flow, vertex_id)
     if isnothing(coefficients)
         alg_helper(data...) = algorithm(data...; coefficients = missing)
@@ -92,11 +100,12 @@ function schedule_graph(event::Event, coefficients::Union{Dagger.Shard, Nothing}
     terminating_results = Dagger.DTask[]
     for vertex_id in event.data_flow.algorithm_indices
         res = schedule_algorithm(event, vertex_id, coefficients)
-        set_prop!(event.store, vertex_id, :res_data, res)
+        put_result!(event, vertex_id, res)
         for v in outneighbors(event.data_flow.graph, vertex_id)
-            set_prop!(event.store, v, :res_data, res)
+            put_result!(event, v, res)
         end
-        is_terminating_alg(event.data_flow.graph, vertex_id) && push!(terminating_results, res)
+        is_terminating_alg(event.data_flow.graph, vertex_id) &&
+            push!(terminating_results, res)
     end
 
     return terminating_results

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -96,7 +96,7 @@ function schedule_algorithm(event::Event, vertex_id::Int,
     end
 end
 
-function schedule_graph(event::Event, coefficients::Union{Dagger.Shard, Nothing})
+function schedule_graph!(event::Event, coefficients::Union{Dagger.Shard, Nothing})
     terminating_results = Dagger.DTask[]
     for vertex_id in event.data_flow.algorithm_indices
         res = schedule_algorithm(event, vertex_id, coefficients)
@@ -131,7 +131,7 @@ function run_pipeline(graph::MetaDiGraph;
             @info dispatch_end_msg(finished_graph_id)
         end
         event = Event(data_flow, idx)
-        terminating_tasks = FrameworkDemo.schedule_graph(event, coefficients)
+        terminating_tasks = FrameworkDemo.schedule_graph!(event, coefficients)
         graphs_tasks[idx] = Dagger.@spawn notify_graph_finalization(notifications, idx,
                                                                     terminating_tasks...)
 

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -31,6 +31,34 @@ function (alg::MockupAlgorithm)(args...; coefficients::Union{Vector{Float64}, Mi
     return alg.name
 end
 
+struct DataFlowGraph
+    graph::MetaDiGraph
+    algorithm_indices::Vector{Int}
+    function DataFlowGraph(graph::MetaDiGraph)
+        alg_vertices = MetaGraphs.filter_vertices(graph, :type, "Algorithm")
+        sorted_vertices = MetaGraphs.topological_sort(graph)
+        sorted_alg_vertices = intersect(sorted_vertices, alg_vertices)
+        for i in sorted_alg_vertices
+            alg = MockupAlgorithm(graph, i)
+            set_prop!(graph, i, :algorithm, alg)
+        end
+        new(graph, sorted_alg_vertices)
+    end
+end
+
+function get_algorithm(data_flow::DataFlowGraph, index::Int)
+    return get_prop(data_flow.graph, index, :algorithm)
+end
+
+struct Event
+    data_flow::DataFlowGraph
+    store::MetaDiGraph
+    event_number::Int
+    function Event(data_flow::DataFlowGraph, event_number::Int = 0)
+        new(data_flow, MetaDiGraph(data_flow.graph), event_number)
+    end
+end
+
 function notify_graph_finalization(notifications::RemoteChannel, graph_id::Int,
                                    terminating_results...)
     println("Graph $graph_id: all tasks in the graph finished!")
@@ -48,10 +76,10 @@ function is_terminating_alg(graph::AbstractGraph, vertex_id::Int)
     all(is_terminating, successor_dataobjects)
 end
 
-function schedule_algorithm(graph::MetaDiGraph, vertex_id::Int,
+function schedule_algorithm(event::Event, vertex_id::Int,
                             coefficients::Union{Dagger.Shard, Nothing})
-    incoming_data = get_promises(graph, inneighbors(graph, vertex_id))
-    algorithm = MockupAlgorithm(graph, vertex_id)
+    incoming_data = get_promises(event.store, inneighbors(event.store, vertex_id))
+    algorithm = get_algorithm(event.data_flow, vertex_id)
     if isnothing(coefficients)
         alg_helper(data...) = algorithm(data...; coefficients = missing)
         return Dagger.@spawn alg_helper(incoming_data...)
@@ -60,20 +88,15 @@ function schedule_algorithm(graph::MetaDiGraph, vertex_id::Int,
     end
 end
 
-function schedule_graph(graph::MetaDiGraph, coefficients::Union{Dagger.Shard, Nothing})
-    alg_vertices = MetaGraphs.filter_vertices(graph, :type, "Algorithm")
-    sorted_vertices = MetaGraphs.topological_sort(graph)
-
-    terminating_results = []
-
-    for vertex_id in intersect(sorted_vertices, alg_vertices)
-        res = schedule_algorithm(graph, vertex_id, coefficients)
-        set_prop!(graph, vertex_id, :res_data, res)
-        for v in outneighbors(graph, vertex_id)
-            set_prop!(graph, v, :res_data, res)
+function schedule_graph(event::Event, coefficients::Union{Dagger.Shard, Nothing})
+    terminating_results = Dagger.DTask[]
+    for vertex_id in event.data_flow.algorithm_indices
+        res = schedule_algorithm(event, vertex_id, coefficients)
+        set_prop!(event.store, vertex_id, :res_data, res)
+        for v in outneighbors(event.data_flow.graph, vertex_id)
+            set_prop!(event.store, v, :res_data, res)
         end
-
-        is_terminating_alg(graph, vertex_id) && push!(terminating_results, res)
+        is_terminating_alg(event.data_flow.graph, vertex_id) && push!(terminating_results, res)
     end
 
     return terminating_results
@@ -90,6 +113,7 @@ function run_pipeline(graph::MetaDiGraph;
     graphs_tasks = Dict{Int, Dagger.DTask}()
     notifications = RemoteChannel(() -> Channel{Int}(max_concurrent))
     coefficients = FrameworkDemo.calibrate_crunch(; fast = fast)
+    data_flow = DataFlowGraph(graph)
 
     for idx in 1:event_count
         while length(graphs_tasks) >= max_concurrent
@@ -97,10 +121,10 @@ function run_pipeline(graph::MetaDiGraph;
             delete!(graphs_tasks, finished_graph_id)
             @info dispatch_end_msg(finished_graph_id)
         end
-
-        terminating_results = FrameworkDemo.schedule_graph(graph, coefficients)
+        event = Event(data_flow, idx)
+        terminating_tasks = FrameworkDemo.schedule_graph(event, coefficients)
         graphs_tasks[idx] = Dagger.@spawn notify_graph_finalization(notifications, idx,
-                                                                    terminating_results...)
+                                                                    terminating_tasks...)
 
         @info dispatch_begin_msg(idx)
     end

--- a/test/demo_workflows.jl
+++ b/test/demo_workflows.jl
@@ -7,7 +7,9 @@ function run_demo(name::String, coefficients::Union{Dagger.Shard, Nothing})
         println("Running $(name) workflow demo")
         path = joinpath(pkgdir(FrameworkDemo), "data/demo/$(name)/df.graphml")
         graph = FrameworkDemo.parse_graphml(path)
-        @test_nowarn wait.(FrameworkDemo.schedule_graph(graph, coefficients))
+        df = FrameworkDemo.DataFlowGraph(graph)
+        event = FrameworkDemo.Event(df)
+        @test_nowarn wait.(FrameworkDemo.schedule_graph(event, coefficients))
     end
 end
 

--- a/test/demo_workflows.jl
+++ b/test/demo_workflows.jl
@@ -9,7 +9,7 @@ function run_demo(name::String, coefficients::Union{Dagger.Shard, Nothing})
         graph = FrameworkDemo.parse_graphml(path)
         df = FrameworkDemo.DataFlowGraph(graph)
         event = FrameworkDemo.Event(df)
-        @test_nowarn wait.(FrameworkDemo.schedule_graph(event, coefficients))
+        @test_nowarn wait.(FrameworkDemo.schedule_graph!(event, coefficients))
     end
 end
 

--- a/test/scheduling.jl
+++ b/test/scheduling.jl
@@ -63,7 +63,7 @@ end
     end
 
     function get_tid(node_id::String)::Int
-        task = get_prop(event.store, graph[node_id, :node_id], :res_data)
+        task = FrameworkDemo.get_result(event, graph[node_id, :node_id])
         return task_to_tid[task.uid]
     end
 

--- a/test/scheduling.jl
+++ b/test/scheduling.jl
@@ -51,7 +51,7 @@ end
     Dagger.enable_logging!(tasknames = true, taskdeps = true)
     _ = Dagger.fetch_logs!() # flush logs
 
-    tasks = FrameworkDemo.schedule_graph(event, coefficients)
+    tasks = FrameworkDemo.schedule_graph!(event, coefficients)
     wait.(tasks)
 
     logs = Dagger.fetch_logs!()

--- a/test/scheduling.jl
+++ b/test/scheduling.jl
@@ -45,10 +45,13 @@ end
     is_fast = "no-fast" ∉ ARGS
     coefficients = FrameworkDemo.calibrate_crunch(; fast = is_fast)
 
+    df = FrameworkDemo.DataFlowGraph(graph)
+    event = FrameworkDemo.Event(df)
+
     Dagger.enable_logging!(tasknames = true, taskdeps = true)
     _ = Dagger.fetch_logs!() # flush logs
 
-    tasks = FrameworkDemo.schedule_graph(graph, coefficients)
+    tasks = FrameworkDemo.schedule_graph(event, coefficients)
     wait.(tasks)
 
     logs = Dagger.fetch_logs!()
@@ -60,7 +63,7 @@ end
     end
 
     function get_tid(node_id::String)::Int
-        task = get_prop(graph, graph[node_id, :node_id], :res_data)
+        task = get_prop(event.store, graph[node_id, :node_id], :res_data)
         return task_to_tid[task.uid]
     end
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Added Event and Dataflow structs
- Fixed event storage for concurrent execution

ENDRELEASENOTES

The pipeline running function introduced in #29 was reusing the parsed graph (graph topology and description) instead of creating a new instance for each event. It went unnoticed that the `schedule_graph` methods mutates the graph by using it for storing algorithms` futures.

As a fix two new structs are introduces:
- `DataFlowGraph` to held immutable information about graph topology and algorithms, and possibly do some graph topology caching
- `Event` holding mutable event specific storage and access to immutable `DataFlowGraph`
- `schedule_graph` is renamed to `schedule_graph!` to indicate it mutates `Event`