### PR TITLE
Add outputing execution plan before running

### DIFF
--- a/bin/schedule.jl
+++ b/bin/schedule.jl
@@ -28,6 +28,10 @@ function parse_args()
         help = "Output graphviz dot file for execution logs graph"
         arg_type = String
 
+        "--dump-plan"
+        help = "Output the execution plan as a graph. Either dot or graphics file format like png, svg, pdf"
+        arg_type = String
+
         "--fast"
         help = "Execute algorithms immediately skipping algorithm runtime information and crunching"
         action = :store_true
@@ -55,6 +59,10 @@ function main()
     event_count = args["event-count"]
     max_concurrent = args["max-concurrent"]
     fast = args["fast"]
+
+    if !isnothing(args["dump-plan"])
+        FrameworkDemo.save_execution_plan(data_flow, args["dump-plan"])
+    end
 
     if args["dry-run"]
         @info "Dry run: not executing workflow, not writing logs"

--- a/bin/schedule.jl
+++ b/bin/schedule.jl
@@ -31,6 +31,10 @@ function parse_args()
         "--fast"
         help = "Execute algorithms immediately skipping algorithm runtime information and crunching"
         action = :store_true
+
+        "--dry-run"
+        help = "Assemble workflow but don't schedule it, don't create any output files"
+        action = :store_true
     end
 
     return ArgParse.parse_args(s)
@@ -51,6 +55,11 @@ function main()
     event_count = args["event-count"]
     max_concurrent = args["max-concurrent"]
     fast = args["fast"]
+
+    if args["dry-run"]
+        @info "Dry run: not executing workflow, not writing logs"
+        return
+    end
 
     @time "Pipeline execution" FrameworkDemo.run_pipeline(data_flow;
                                                           event_count = event_count,

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -20,3 +20,50 @@ function save_logs_dot(logs, path::String)
         @info "Written logs graph to $path"
     end
 end
+
+function get_execution_plan(df::DataFlowGraph)::MetaDiGraph
+    g = MetaDiGraph()
+    for (i, v) in enumerate(df.algorithm_indices)
+        add_vertex!(g)
+        label = get_name(get_prop(df.graph, i, :algorithm))
+        set_prop!(g, i, :label, label)
+    end
+    set_indexing_prop!(g, :label)
+    dataobject_indices = filter_vertices(df.graph, :type, "DataObject")
+
+    get_algs(indices) = get_prop.(Ref(df.graph), indices, Ref(:algorithm))
+    names_to_vertices(labels) = getindex.(Ref(g), labels, Ref(:label))
+    translate_alg_vertices(indices) = indices |> get_algs .|>
+                                      get_name .|> names_to_vertices
+
+    for dataobject_idx in dataobject_indices
+        predecessors_vertices = inneighbors(df.graph, dataobject_idx) |>
+                                translate_alg_vertices
+        successors_vertices = outneighbors(df.graph, dataobject_idx) |>
+                              translate_alg_vertices
+        for (i, j) in Iterators.product(predecessors_vertices, successors_vertices)
+            if !has_edge(g, i, j)
+                add_edge!(g, i, j)
+            end
+        end
+    end
+    return g
+end
+
+function save_execution_plan(df::DataFlowGraph, path::String)
+    g = get_execution_plan(df)
+    if splitext(path)[2] == ".dot"
+        open(path, "w") do io
+            MetaGraphs.savedot(io, g)
+            @info "Written execution plan dot graph to $path"
+        end
+    else
+        buffer = IOBuffer()
+        MetaGraphs.savedot(buffer, g)
+        dot = String(take!(buffer))
+        graphviz = GraphViz.Graph(dot)
+        GraphViz.layout!(graphviz; engine = "dot")
+        FileIO.save(path, graphviz)
+        @info "Written execution plan graph to $path"
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,4 +25,5 @@ end
     include("parsing.jl")
     include("scheduling.jl")
     include("demo_workflows.jl")
+    include("visualization.jl")
 end

--- a/test/visualization.jl
+++ b/test/visualization.jl
@@ -1,0 +1,22 @@
+using FrameworkDemo
+using Test
+using Graphs
+using MetaGraphs
+
+@testset "Visualization" begin
+    graph = joinpath(pkgdir(FrameworkDemo), "data/demo/datadeps/df.graphml") |>
+            FrameworkDemo.parse_graphml |> FrameworkDemo.mockup_dataflow |>
+            FrameworkDemo.get_execution_plan
+
+    @test nv(graph) == 7
+    @test ne(graph) == 7
+    has_edge(x::String, y::String) = Graphs.has_edge(graph, graph[x, :label],
+                                                     graph[y, :label])
+    @test has_edge("ProducerA", "TransformerAB")
+    @test has_edge("ProducerBC", "TransformerAB")
+    @test has_edge("ProducerBC", "ConsumerBC")
+    @test has_edge("ProducerBC", "TransformerC")
+    @test has_edge("ProducerBC", "ConsumerCD")
+    @test has_edge("TransformerAB", "ConsumerE")
+    @test has_edge("TransformerAB", "ConsumerCD")
+end


### PR DESCRIPTION
BEGINRELEASENOTES
- Added `dry-run` option to assemble the workflow but skip scheduling it
- Added `dump-plan` option to output execution plan

ENDRELEASENOTES

Adding options to allowing checking inspecting the correctness of graph to be scheduled before it's executed. The `dump-plan` option can produce either textual dot graph or graphical representation of it. The execution graph shows the algortihm vertices and data dependencies between them (no dataobject vertices)

Example:
- Input: data flow
  ![df](https://github.com/user-attachments/assets/21e71410-022b-4a92-b528-1349daf64391) 
- :sparkles:  **New** :sparkles: Output: plan
  ![plan](https://github.com/user-attachments/assets/8dc2688f-7252-4751-8ada-988324bc5a73) 
- Output: logs
  ![trace](https://github.com/user-attachments/assets/787020ab-f913-42b8-a842-cf2bb1302718)
