### PR TITLE
Add saving raw logs as text file

### DIFF
--- a/bin/schedule.jl
+++ b/bin/schedule.jl
@@ -28,6 +28,10 @@ function parse_args()
         help = "Output the execution logs as a graph. Either dot or graphics file format like png, svg, pdf"
         arg_type = String
 
+        "--logs-raw"
+        help = "Output the execution logs as text"
+        arg_type = String
+
         "--dump-plan"
         help = "Output the execution plan as a graph. Either dot or graphics file format like png, svg, pdf"
         arg_type = String
@@ -47,7 +51,7 @@ end
 function main()
     args = parse_args()
 
-    logging_required = !isnothing(args["logs-graph"])
+    logging_required = !isnothing(args["logs-graph"]) || !isnothing(args["logs-raw"])
 
     if logging_required
         FrameworkDemo.configure_LocalEventLog()
@@ -77,6 +81,9 @@ function main()
         logs = FrameworkDemo.fetch_logs!()
         if !isnothing(args["logs-graph"])
             FrameworkDemo.save_logs_dot(logs, args["logs-graph"])
+        end
+        if !isnothing(args["logs-raw"])
+            FrameworkDemo.save_logs_raw(logs, args["logs-raw"])
         end
     end
 end

--- a/bin/schedule.jl
+++ b/bin/schedule.jl
@@ -24,8 +24,8 @@ function parse_args()
         arg_type = Int
         default = 1
 
-        "--dot-trace"
-        help = "Output graphviz dot file for execution logs graph"
+        "--logs-graph"
+        help = "Output the execution logs as a graph. Either dot or graphics file format like png, svg, pdf"
         arg_type = String
 
         "--dump-plan"
@@ -47,7 +47,7 @@ end
 function main()
     args = parse_args()
 
-    logging_required = !isnothing(args["dot-trace"])
+    logging_required = !isnothing(args["logs-graph"])
 
     if logging_required
         FrameworkDemo.configure_LocalEventLog()
@@ -75,8 +75,8 @@ function main()
                                                           fast = fast)
     if logging_required
         logs = FrameworkDemo.fetch_logs!()
-        if !isnothing(args["dot-trace"])
-            FrameworkDemo.save_logs_dot(logs, args["dot-trace"])
+        if !isnothing(args["logs-graph"])
+            FrameworkDemo.save_logs_dot(logs, args["logs-graph"])
         end
     end
 end

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -21,6 +21,13 @@ function save_logs_dot(logs, path::String)
     end
 end
 
+function save_logs_raw(logs, path::String)
+    open(path, "w") do io
+        println(io, logs)
+        @info "Written raw logs to $path"
+    end
+end
+
 function get_execution_plan(df::DataFlowGraph)::MetaDiGraph
     g = MetaDiGraph()
     for (i, v) in enumerate(df.algorithm_indices)


### PR DESCRIPTION
BEGINRELEASENOTES
- Renamed `--dot-trace` option to `--logs-graph`
- Added `--logs-raw` option for saving Dagger logs to a text file. 

ENDRELEASENOTES

Implementation of text logs for LocalEventLog for #34. Should  be also working with MultiEventLog. The readability of raw logs is limited but it's the most complete information becasue or other options do some kind of filtering and processing of these.  