### PR TITLE
Fix magic numbers in crunching, use wrappers for logging

### DIFF
--- a/src/cpu_crunching.jl
+++ b/src/cpu_crunching.jl
@@ -29,8 +29,8 @@ function benchmark_prime(n::Int)
     return Δt
 end
 
-function calculate_coefficients()::Vector{Float64}
-    n_max = [1000, 200_000]
+function calculate_coefficients(min = 1000, max = 200_000)::Vector{Float64}
+    n_max = [min, max]
     t_average = benchmark_prime.(n_max)
 
     return inv([n_max[i]^j for i in 1:2, j in 1:2]) * t_average

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -10,6 +10,10 @@ function fetch_logs!()
     return Dagger.fetch_logs!()
 end
 
+function disable_logging!()
+    Dagger.disable_logging!()
+end
+
 function dispatch_begin_msg(index)
     "Dispatcher: scheduled graph $index"
 end

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -148,8 +148,9 @@ function schedule_graph!(event::Event, coefficients::Union{Dagger.Shard, Nothing
     return terminating_results
 end
 
-function calibrate_crunch(; fast::Bool = false)::Union{Dagger.Shard, Nothing}
-    return fast ? nothing : Dagger.@shard calculate_coefficients()
+function calibrate_crunch(min::Int = 1000, max::Int = 200_000;
+                          fast::Bool = false)::Union{Dagger.Shard, Nothing}
+    return fast ? nothing : Dagger.@shard calculate_coefficients(min, max)
 end
 
 function run_pipeline(data_flow::DataFlowGraph;

--- a/test/cpu_crunching.jl
+++ b/test/cpu_crunching.jl
@@ -1,0 +1,9 @@
+using Test
+using FrameworkDemo
+
+@testset "cpu_crunching" begin
+    coefficients = FrameworkDemo.calculate_coefficients(10, 100)
+    @test !isnothing(coefficients)
+    @test all(x -> !ismissing(x) && !isnan(x), coefficients)
+    @test any(x -> !iszero(x), coefficients)
+end

--- a/test/demo_workflows.jl
+++ b/test/demo_workflows.jl
@@ -14,7 +14,7 @@ function run_demo(name::String, coefficients::Union{Dagger.Shard, Nothing})
 end
 
 @testset "Demo workflows" begin
-    Dagger.disable_logging!()
+    FrameworkDemo.disable_logging!()
     is_fast = "no-fast" ∉ ARGS
     coefficients = FrameworkDemo.calibrate_crunch(; fast = is_fast)
     run(name) = run_demo(name, coefficients)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ end
         include("Aqua.jl")
     end
     include("parsing.jl")
+    include("cpu_crunching.jl")
     include("scheduling.jl")
     include("demo_workflows.jl")
     include("visualization.jl")

--- a/test/scheduling.jl
+++ b/test/scheduling.jl
@@ -49,13 +49,13 @@ end
     event = FrameworkDemo.Event(df)
 
     Dagger.enable_logging!(tasknames = true, taskdeps = true)
-    _ = Dagger.fetch_logs!() # flush logs
+    _ = FrameworkDemo.fetch_logs!() # flush logs
 
     tasks = FrameworkDemo.schedule_graph!(event, coefficients)
     wait.(tasks)
 
-    logs = Dagger.fetch_logs!()
-    Dagger.disable_logging!()
+    logs = FrameworkDemo.fetch_logs!()
+    FrameworkDemo.disable_logging!()
     @test !isnothing(logs)
 
     task_to_tid = lock(Dagger.Sch.EAGER_ID_MAP) do id_map


### PR DESCRIPTION
BEGINRELEASENOTES
- Using FrameworkDemo flavored logging functions
- Removed magic numbers from crunching

ENDRELEASENOTES
