### PR TITLE
fix error with unregistering worker and type conversion

### DIFF
--- a/bin/schedule.jl
+++ b/bin/schedule.jl
@@ -104,6 +104,6 @@ function (@main)(raw_args)
 
     if length(workers()) > 1
         rmprocs!(Dagger.Sch.eager_context(), workers())
-        rmprocs(workers())
+        workers() |> rmprocs |> wait
     end
 end


### PR DESCRIPTION
BEGINRELEASENOTES
- Fixed error with unregistering worker  and invalid return type conversion

ENDRELEASENOTES

Added missing `wait` so the `rmprocs` task is finished before exit leaving the program in cleaner state. The task was also implicitly used as a return code of `@main` when using remote workers - now the implicitly returned values is `nothing` which results in `0` exit code from the program