### PR TITLE
use julia-runtest from tag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,6 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
-      # change to julia-actions/julia-runtest@v1.11 once it's available
-      - uses: julia-actions/julia-runtest@main
+      - uses: julia-actions/julia-runtest@v1
         with:
           test_args: ${{matrix.test_args}}


### PR DESCRIPTION
BEGINRELEASENOTES
- Updated version of testing CI

ENDRELEASENOTES

Test arguments are now supported in the [julia-runtest](https://github.com/julia-actions/julia-runtest/releases/tag/v1.11.0)