### PR TITLE
fix type instabilities

### DIFF
--- a/src/mockup.jl
+++ b/src/mockup.jl
@@ -18,7 +18,7 @@ struct MockupAlgorithm <: AbstractAlgorithm
     end
 end
 
-mockup_alg_default_runtime_s::Float64 = 0
+const mockup_alg_default_runtime_s = 0
 
 function (alg::MockupAlgorithm)(args...; event_number::Int,
                                 coefficients::Union{Vector{Float64}, Missing})

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -28,7 +28,7 @@ function get_name(alg::BoundAlgorithm)
 end
 
 struct DataFlowGraph
-    graph::MetaDiGraph
+    graph::MetaDiGraph{Int, Float64}
     algorithm_indices::Vector{Int}
     function DataFlowGraph(graph::MetaDiGraph)
         alg_vertices = MetaGraphs.filter_vertices(graph, :type, "Algorithm")

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -13,8 +13,8 @@ function get_name(alg::AbstractAlgorithm)
     error("Subtypes of AbstractAlgorithm must implement get_name")
 end
 
-struct BoundAlgorithm
-    alg::AbstractAlgorithm
+struct BoundAlgorithm{T <: AbstractAlgorithm}
+    alg::T
     event_number::Int
 end
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Fixed type instabilities due to using global variable, abstract type field and unspecified parametric type field

ENDRELEASENOTES

Fixing minor issues with type instabilities:
- non-const global
- struct with abstract type
- struct with unspecified parametric type