### PR TITLE
use fork of distributed with fix for thread-safety

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,9 +17,9 @@ MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
-[sources.GraphMLReader]
-rev = "master"
-url = "https://github.com/SmalRat/GraphMLReader.jl"
+[sources]
+Distributed = {rev = "jps/threadsafe_workerstate", url = "https://github.com/JamesWrigley/Distributed.jl"}
+GraphMLReader = {rev = "master", url = "https://github.com/SmalRat/GraphMLReader.jl"}
 
 [compat]
 Aqua = "0.8"

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 FrameworkDemo = "cfbf7e84-66d2-421e-b147-9edb7a8672d2"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -7,6 +8,7 @@ GraphMLReader = "8e6830a9-644c-4485-8539-40ee18e3ca8c"
 
 [compat]
 BenchmarkTools = "1.5"
+Distributed = "1.11"
 FrameworkDemo = "0.1"
 GraphMLReader = "0.1"
 Plots = "1.40"
@@ -14,5 +16,6 @@ Printf = "1.11"
 julia = "1.11"
 
 [sources]
+Distributed = {rev = "jps/threadsafe_workerstate", url = "https://github.com/JamesWrigley/Distributed.jl"}
 FrameworkDemo = {path = ".."}
 GraphMLReader = {rev = "master", url = "https://github.com/SmalRat/GraphMLReader.jl"}


### PR DESCRIPTION
BEGINRELEASENOTES
- Switched to fork of Distributed with fixed thread-safety

ENDRELEASENOTES

With Julia 1.10 we experience errors when using multiple-processes due to thread-unsafties in Distributed.
With Julia 1.11 surprisingly the errors seems to disappear even though the thread-safety in Distributed wasn't improved yet.

As per recommendation branch with thread-safeties will be used for now
To be removed once JuliaLang/Distributed.jl#101 is merged 