### PR TITLE
use DistributedNext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ Manifest.toml
 
 # Data/results/output files
 results/
+
+# Local Julia preferences
+LocalPreferences.toml

--- a/Project.toml
+++ b/Project.toml
@@ -48,7 +48,9 @@ julia = "1.11"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+MemPool = "f9f48841-c794-520a-933b-121f7ba6ed94"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TimespanLogging = "a526e669-04d3-4846-9525-c66122c55f63"
 
 [targets]
 test = ["Aqua", "Logging", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -59,9 +59,12 @@ test = ["Aqua", "Logging", "Test"]
 
 [preferences.Dagger]
 distributed-package = "DistributedNext"
+
 [preferences.FrameworkDemo]
 distributed-package = "DistributedNext"
+
 [preferences.MemPool]
 distributed-package = "DistributedNext"
+
 [preferences.TimespanLogging]
 distributed-package = "DistributedNext"

--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ GraphMLReader = {rev = "master", url = "https://github.com/SmalRat/GraphMLReader
 Aqua = "0.8"
 ArgParse = "1.2"
 CSV = "0.10"
-Dagger = "0.18.13"
+Dagger = "0.18.14"
 DataFrames = "1.6"
 Distributed = "1.11"
 DistributedNext = "1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -59,6 +59,8 @@ test = ["Aqua", "Logging", "Test"]
 
 [preferences.Dagger]
 distributed-package = "DistributedNext"
+[preferences.FrameworkDemo]
+distributed-package = "DistributedNext"
 [preferences.MemPool]
 distributed-package = "DistributedNext"
 [preferences.TimespanLogging]

--- a/Project.toml
+++ b/Project.toml
@@ -38,11 +38,13 @@ GraphViz = "0.2"
 Graphs = "1"
 JSON3 = "1.14"
 Logging = "1.11"
+MemPool = "0.4.12"
 MetaGraphs = "0.7, 0.8"
 Plots = "1.40"
 Preferences = "1.4"
 Printf = "1.11"
 Test = "1.11"
+TimespanLogging = "0.1.0"
 julia = "1.11"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -44,7 +44,7 @@ Plots = "1.40"
 Preferences = "1.4"
 Printf = "1.11"
 Test = "1.11"
-TimespanLogging = "0.1.0"
+TimespanLogging = "0.1.1"
 julia = "1.11"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 Dagger = "d58978e5-989f-55fb-8d15-ea34adc7bf54"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+DistributedNext = "fab6aee4-877b-4bac-a744-3eca44acbb6f"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 GraphMLReader = "8e6830a9-644c-4485-8539-40ee18e3ca8c"
 GraphViz = "f526b714-d49f-11e8-06ff-31ed36ee7ee0"
@@ -17,6 +18,7 @@ JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [sources]
@@ -29,6 +31,7 @@ CSV = "0.10"
 Dagger = "0.18.13"
 DataFrames = "1.6"
 Distributed = "1.11"
+DistributedNext = "1.0"
 FileIO = "1.16"
 GraphMLReader = "0.1"
 GraphViz = "0.2"
@@ -37,6 +40,7 @@ JSON3 = "1.14"
 Logging = "1.11"
 MetaGraphs = "0.7, 0.8"
 Plots = "1.40"
+Preferences = "1.4"
 Printf = "1.11"
 Test = "1.11"
 julia = "1.11"
@@ -48,3 +52,10 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Aqua", "Logging", "Test"]
+
+[preferences.Dagger]
+distributed-package = "DistributedNext"
+[preferences.MemPool]
+distributed-package = "DistributedNext"
+[preferences.TimespanLogging]
+distributed-package = "DistributedNext"

--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ using FrameworkDemo
 
 ## Preferences
 
-The [Preferences](https://juliapackaging.github.io/Preferences.jl/stable/) are used to select whether [DistributedNext](https://github.com/JuliaParallel/DistributedNext.jl) (default) or [Distributed](https://github.com/JuliaLang/Distributed.jl) is used.
+The [Preferences](https://juliapackaging.github.io/Preferences.jl/stable/) are used to select whether [DistributedNext](https://github.com/JuliaParallel/DistributedNext.jl) (default) or [Distributed](https://github.com/JuliaLang/Distributed.jl) is used for distributed computing.
 The preferences can be changed with:
 
 ```julia
 julia --project -e "using FrameworkDemo; FrameworkDemo.set_distributed_package!(\"Distributed\")"
 ```
+
+The changes will be stored in `LocalPreferences.toml` in the project directory which overwrites the default preferences in [`Project.toml`](Project.toml).

--- a/README.md
+++ b/README.md
@@ -29,3 +29,12 @@ or use with REPL:
 ```julia
 using FrameworkDemo
 ```
+
+## Preferences
+
+The [Preferences](https://juliapackaging.github.io/Preferences.jl/stable/) are used to select whether [DistributedNext](https://github.com/JuliaParallel/DistributedNext.jl) (default) or [Distributed](https://github.com/JuliaLang/Distributed.jl) is used.
+The preferences can be changed with:
+
+```julia
+julia --project -e "using FrameworkDemo; FrameworkDemo.set_distributed_package!(\"Distributed\")"
+```

--- a/bin/schedule.jl
+++ b/bin/schedule.jl
@@ -1,7 +1,7 @@
 #!/usr/bin/env julia
 
 import Preferences
-if Preferences.load_preference("Dagger", "distributed-package") == "DistributedNext"
+if Preferences.@load_preference("distributed-package") == "DistributedNext"
     using DistributedNext
 else
     using Distributed

--- a/bin/schedule.jl
+++ b/bin/schedule.jl
@@ -1,6 +1,11 @@
 #!/usr/bin/env julia
 
-using Distributed
+import Preferences
+if Preferences.load_preference("Dagger", "distributed-package") == "DistributedNext"
+    using DistributedNext
+else
+    using Distributed
+end
 using Dagger
 using ArgParse
 using FrameworkDemo

--- a/src/FrameworkDemo.jl
+++ b/src/FrameworkDemo.jl
@@ -1,9 +1,9 @@
 module FrameworkDemo
 import Preferences
 if Preferences.load_preference("Dagger", "distributed-package") == "DistributedNext"
-     using DistributedNext
+    using DistributedNext
 else
-     using Distributed
+    using Distributed
 end
 include("logging.jl")
 include("parsing.jl")

--- a/src/FrameworkDemo.jl
+++ b/src/FrameworkDemo.jl
@@ -1,5 +1,10 @@
 module FrameworkDemo
-
+import Preferences
+if Preferences.load_preference("Dagger", "distributed-package") == "DistributedNext"
+     using DistributedNext
+else
+     using Distributed
+end
 include("logging.jl")
 include("parsing.jl")
 include("scheduling.jl")

--- a/src/FrameworkDemo.jl
+++ b/src/FrameworkDemo.jl
@@ -1,10 +1,5 @@
 module FrameworkDemo
-import Preferences
-if Preferences.load_preference("Dagger", "distributed-package") == "DistributedNext"
-    using DistributedNext
-else
-    using Distributed
-end
+
 include("logging.jl")
 include("parsing.jl")
 include("scheduling.jl")

--- a/src/FrameworkDemo.jl
+++ b/src/FrameworkDemo.jl
@@ -11,5 +11,6 @@ include("scheduling.jl")
 include("visualization.jl")
 include("cpu_crunching.jl")
 include("mockup.jl")
+include("preferences.jl")
 
 end # FrameworkDemo

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -5,13 +5,7 @@ function set_distributed_package!(package_name::String)
     if package_name ∉ ("Distributed", "DistributedNext")
         throw(ArgumentError("Invalid distributed package: $(package_name)"))
     end
-    Preferences.set_preferences!("Dagger", "distributed-package" => package_name;
-                                 force = true)
-    Preferences.set_preferences!("MemPool", "distributed-package" => package_name;
-                                 force = true)
-    Preferences.set_preferences!("TimespanLogging", "distributed-package" => package_name;
-                                 force = true)
-    Preferences.set_preferences!("FrameworkDemo", "distributed-package" => package_name;
-                                 force = true)
-    @info("Preferences updated; restart your Julia session to take effect!")
+    Dagger.set_distributed_package!(package_name)
+    Preferences.@set_preferences!("distributed-package" => package_name)
+    @info("Preferences updated, restart your Julia session for this change to take effect")
 end

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -6,6 +6,6 @@ function set_distributed_package!(package_name::String)
         throw(ArgumentError("Invalid distributed package: $(package_name)"))
     end
     Dagger.set_distributed_package!(package_name)
-    Preferences.@set_preferences!("distributed-package" => package_name)
+    Preferences.@set_preferences!("distributed-package"=>package_name)
     @info("Preferences updated, restart your Julia session for this change to take effect")
 end

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -1,0 +1,17 @@
+import Dagger
+import Preferences
+
+function set_distributed_package!(package_name::String)
+    if package_name ∉ ("Distributed", "DistributedNext")
+        throw(ArgumentError("Invalid distributed package: $(package_name)"))
+    end
+    Preferences.set_preferences!("Dagger", "distributed-package" => package_name;
+                                 force = true)
+    Preferences.set_preferences!("MemPool", "distributed-package" => package_name;
+                                 force = true)
+    Preferences.set_preferences!("TimespanLogging", "distributed-package" => package_name;
+                                 force = true)
+    Preferences.set_preferences!("FrameworkDemo", "distributed-package" => package_name;
+                                 force = true)
+    @info("Preferences updated; restart your Julia session to take effect!")
+end

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -1,5 +1,11 @@
 import Dagger
 using MetaGraphs
+import Preferences
+if Preferences.@load_preference("distributed-package") == "DistributedNext"
+    using DistributedNext
+else
+    using Distributed
+end
 
 abstract type AbstractAlgorithm end
 

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -1,5 +1,4 @@
 import Dagger
-using Distributed
 using MetaGraphs
 
 abstract type AbstractAlgorithm end

--- a/test/preferences.jl
+++ b/test/preferences.jl
@@ -1,0 +1,14 @@
+using Test
+using Preferences
+
+@testset "Preferences" begin
+    distributed_package = Preferences.load_preference("FrameworkDemo",
+                                                      "distributed-package")
+    @test distributed_package ∈ ("Distributed", "DistributedNext")
+    @test Preferences.load_preference("Dagger", "distributed-package") ==
+          distributed_package
+    @test Preferences.load_preference("MemPool", "distributed-package") ==
+          distributed_package
+    @test Preferences.load_preference("TimespanLogging", "distributed-package") ==
+          distributed_package
+end

--- a/test/preferences.jl
+++ b/test/preferences.jl
@@ -7,8 +7,4 @@ using Preferences
     @test distributed_package ∈ ("Distributed", "DistributedNext")
     @test Preferences.load_preference("Dagger", "distributed-package") ==
           distributed_package
-    @test Preferences.load_preference("MemPool", "distributed-package") ==
-          distributed_package
-    @test Preferences.load_preference("TimespanLogging", "distributed-package") ==
-          distributed_package
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,7 @@ end
     if "all" ∈ ARGS
         include("Aqua.jl")
     end
+    include("preferences.jl")
     include("parsing.jl")
     include("cpu_crunching.jl")
     include("scheduling.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,7 @@ end
       n_workers=nworkers(),
       n_procs=nprocs(),
       n_threads=Threads.nthreads(),
+      distrbuted_package=Preferences.load_preference("Dagger", "distributed-package"),
       test_args=repr(ARGS))
 
 @testset verbose=true "FrameworkDemo.jl" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,9 @@
-using Distributed
+import Preferences
+if Preferences.load_preference("Dagger", "distributed-package") == "DistributedNext"
+    using DistributedNext
+else
+    using Distributed
+end
 using Test
 
 if abspath(PROGRAM_FILE) == @__FILE__
@@ -13,8 +18,8 @@ end
 
 @info("Execution environment details",
       julia_version=VERSION,
-      n_workers=Distributed.nworkers(),
-      n_procs=Distributed.nprocs(),
+      n_workers=nworkers(),
+      n_procs=nprocs(),
       n_threads=Threads.nthreads(),
       test_args=repr(ARGS))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 import Preferences
-if Preferences.load_preference("Dagger", "distributed-package") == "DistributedNext"
+if Preferences.load_preference("FrameworkDemo", "distributed-package") == "DistributedNext"
     using DistributedNext
 else
     using Distributed
@@ -21,7 +21,8 @@ end
       n_workers=nworkers(),
       n_procs=nprocs(),
       n_threads=Threads.nthreads(),
-      distrbuted_package=Preferences.load_preference("Dagger", "distributed-package"),
+      distributed_package=Preferences.load_preference("FrameworkDemo",
+                                                      "distributed-package"),
       test_args=repr(ARGS))
 
 @testset verbose=true "FrameworkDemo.jl" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,19 +1,20 @@
+using Test
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    import Pkg
+    try
+        Pkg.test(; test_args = ARGS)
+        exit(0)
+    catch
+        exit(1)
+    end
+end
+
 import Preferences
 if Preferences.load_preference("FrameworkDemo", "distributed-package") == "DistributedNext"
     using DistributedNext
 else
     using Distributed
-end
-using Test
-
-if abspath(PROGRAM_FILE) == @__FILE__
-    if !isnothing(Base.find_package("TestEnv"))
-        import TestEnv
-        TestEnv.activate()
-    else
-        @error "Install TestEnv package for running manually"
-        exit(1)
-    end
 end
 
 @info("Execution environment details",


### PR DESCRIPTION
BEGINRELEASENOTES
- Added mechanism to select package used for distributed computing - either `Distributed` standard library or its thread-safe fork `DistributedNext`.

ENDRELEASENOTES

Dagger introduced support for [DistributedNext](https://github.com/JuliaParallel/DistributedNext.jl) - a thread-safe fork of Distributed since due to bugs in it, it was impossible to consistently schedule jobs using multiprocess:multithread

In this PR a mechanism using `Preferences` is used to configure which package will be used for distributed computing. As per recommendation the default is `DistributedNext`

Supersedes #61 