### PR TITLE
move calibrating cpu crunchers outside of pipeline

### DIFF
--- a/bin/schedule.jl
+++ b/bin/schedule.jl
@@ -82,10 +82,12 @@ function (@main)(raw_args)
         return
     end
 
+    crunch_coefficients = FrameworkDemo.calibrate_crunch(; fast = fast)
+
     @time "Pipeline execution" FrameworkDemo.run_pipeline(data_flow;
                                                           event_count = event_count,
                                                           max_concurrent = max_concurrent,
-                                                          fast = fast)
+                                                          crunch_coefficients = crunch_coefficients)
     if logging_required
         logs = FrameworkDemo.fetch_logs!()
         for format in logs_formats

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -113,10 +113,9 @@ end
 function run_pipeline(data_flow::DataFlowGraph;
                       event_count::Int,
                       max_concurrent::Int,
-                      fast::Bool = false)
+                      crunch_coefficients::Union{Dagger.Shard, Nothing} = nothing,)
     graphs_tasks = Dict{Int, Dagger.DTask}()
     notifications = RemoteChannel(() -> Channel{Int}(max_concurrent))
-    coefficients = FrameworkDemo.calibrate_crunch(; fast = fast)
 
     for idx in 1:event_count
         while length(graphs_tasks) >= max_concurrent
@@ -125,7 +124,7 @@ function run_pipeline(data_flow::DataFlowGraph;
             @info dispatch_end_msg(finished_graph_id)
         end
         event = Event(data_flow, idx)
-        terminating_tasks = FrameworkDemo.schedule_graph!(event, coefficients)
+        terminating_tasks = FrameworkDemo.schedule_graph!(event, crunch_coefficients)
         graphs_tasks[idx] = Dagger.@spawn notify_graph_finalization(notifications, idx,
                                                                     terminating_tasks...)
 

--- a/test/scheduling.jl
+++ b/test/scheduling.jl
@@ -104,7 +104,7 @@ end
             FrameworkDemo.run_pipeline(data_flow;
                                        max_concurrent = 3,
                                        event_count = event_count,
-                                       fast = is_fast)
+                                       crunch_coefficients = coefficients)
         end
         @testset "Start message" begin
             messages = for i in 1:event_count


### PR DESCRIPTION
BEGINRELEASENOTES
- Move CPU-crunching calibration outside of event pipeline as it was artificially increasing reported execution times

ENDRELEASENOTES

CPU-crunching calibration is a part of the setup to run the mockups with CPU-crunchers. It's quite slow and when put inside pipeline inflate the reported execution duration, so it's better to move it outside