### PR TITLE
Fix broken dot output for graph vertices containing `<` `>`

### DIFF
--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -2,6 +2,17 @@ using Graphs
 using MetaGraphs
 import GraphMLReader
 
+"Poor man's node ids encoding with selected HTML entities"
+function encode_ids!(g)
+    for i in vertices(g)
+        label = get_prop(g, i, :node_id)
+        encoded_label = replace(label, "<" => "&lt;", ">" => "&gt;")
+        set_prop!(g, i, :node_id, encoded_label)
+    end
+end
+
 function parse_graphml(filename::String)::MetaDiGraph
-    return GraphMLReader.loadgraphml(filename, "G")
+    g = GraphMLReader.loadgraphml(filename, "G")
+    encode_ids!(g)
+    return g
 end

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -95,8 +95,8 @@ function save_execution_plan(df::DataFlowGraph, path::String)
     else
         buffer = IOBuffer()
         MetaGraphs.savedot(buffer, g)
-        dot = String(take!(buffer))
-        graphviz = GraphViz.Graph(dot)
+        seekstart(buffer)
+        graphviz = GraphViz.Graph(buffer)
         GraphViz.layout!(graphviz; engine = "dot")
         FileIO.save(path, graphviz)
         @info "Written execution plan graph to $path"


### PR DESCRIPTION
BEGINRELEASENOTES
- Add workaround to fix a problem with obtaining non-conforming .dot output when graph vertices labels contain `<` or `>` characters
- Don't convert buffers to streams if not necessary 

ENDRELEASENOTES

I noticed that getting outputs for q449 workflow is broken as the MetaGraphs translate vertex labels like `LArFlatConditionsAlg&lt;LArOFCFlat&gt;` to `LArFlatConditionsAlg<LArOFCFlat>` (correctly) but then assume it's a HTML tag and doesn't ecape it with quotes in dot format.

https://github.com/JuliaGraphs/MetaGraphs.jl/blob/82865e3d4db4220a66f3d5be2cfc9739f5cd849a/src/persistence.jl#L23-32

As a workaround I propose to translate back the offending characters to their HTML entities encoding. This will probably be easier than fixing MetaGraphs due to maintenance problems

@SmalRat 