### PR TITLE
Rename dagger logging to tracing, replace printing with real logging

### DIFF
--- a/bin/schedule.jl
+++ b/bin/schedule.jl
@@ -5,7 +5,7 @@ using Dagger
 using ArgParse
 using FrameworkDemo
 
-const logs_formats = ["graph", "trace", "gantt", "raw"]
+const trace_formats = ["graph", "chrome", "gantt", "raw"]
 
 function parse_args(raw_args)
     s = ArgParseSettings()
@@ -26,20 +26,20 @@ function parse_args(raw_args)
         arg_type = Int
         default = 1
 
-        "--logs-graph"
-        help = "Output the execution logs as a graph. Either dot or graphics file format like png, svg, pdf"
+        "--trace-graph"
+        help = "Output the execution trace as a graph. Either dot or graphics file format like png, svg, pdf"
         arg_type = String
 
-        "--logs-trace"
-        help = "Output the execution logs as a chrome trace. Must be a json file"
+        "--trace-chrome"
+        help = "Output the execution trace as a chrome trace. Must be a json file"
         arg_type = String
 
-        "--logs-gantt"
-        help = "Output the execution logs as a Gantt chart. Must be a graphics file format like png, svg, pdf"
+        "--trace-gantt"
+        help = "Output the execution trace as a Gantt chart. Must be a graphics file format like png, svg, pdf"
         arg_type = String
 
-        "--logs-raw"
-        help = "Output the execution logs as text. The file will be formatted as json if json extension is given"
+        "--trace-raw"
+        help = "Output the execution trace as text. The file will be formatted as json if json extension is given"
         arg_type = String
 
         "--dump-plan"
@@ -60,11 +60,11 @@ end
 
 function (@main)(raw_args)
     args = parse_args(raw_args)
-    logging_required = any(x -> !isnothing(args["logs-$x"]), logs_formats)
+    tracing_required = any(x -> !isnothing(args["trace-$x"]), trace_formats)
 
-    if logging_required
-        FrameworkDemo.enable_logging!()
-        @info "Enabled logging"
+    if tracing_required
+        FrameworkDemo.enable_tracing!()
+        @info "Enabled tracing"
     end
 
     graph = FrameworkDemo.parse_graphml(args["data-flow"])
@@ -78,7 +78,7 @@ function (@main)(raw_args)
     end
 
     if args["dry-run"]
-        @info "Dry run: not executing workflow, not writing logs"
+        @info "Dry run: not executing workflow, not writing traces"
         return
     end
 
@@ -88,12 +88,13 @@ function (@main)(raw_args)
                                                           event_count = event_count,
                                                           max_concurrent = max_concurrent,
                                                           crunch_coefficients = crunch_coefficients)
-    if logging_required
-        logs = FrameworkDemo.fetch_logs!()
-        for format in logs_formats
-            path = args["logs-$format"]
+
+    if tracing_required
+        trace = FrameworkDemo.fetch_trace!()
+        for format in trace_formats
+            path = args["trace-$format"]
             if !isnothing(path)
-                FrameworkDemo.save_logs(logs, path, Symbol(format))
+                FrameworkDemo.save_trace(trace, path, Symbol(format))
             end
         end
     end

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -1,6 +1,6 @@
 using Dagger
 
-function enable_logging!()
+function enable_tracing!()
     Dagger.enable_logging!(tasknames = true,
                            taskfuncnames = true,
                            taskdeps = true,
@@ -11,11 +11,11 @@ function enable_logging!()
                            tasktochunk = true)
 end
 
-function disable_logging!()
+function disable_tracing!()
     Dagger.disable_logging!()
 end
 
-function fetch_logs!()
+function fetch_trace!()
     return Dagger.fetch_logs!()
 end
 

--- a/src/mockup.jl
+++ b/src/mockup.jl
@@ -22,7 +22,7 @@ const mockup_alg_default_runtime_s = 0
 
 function (alg::MockupAlgorithm)(args...; event_number::Int,
                                 coefficients::Union{Vector{Float64}, Missing})
-    println("Executing $(alg.name) event $event_number")
+    @info "Executing $(alg.name) event $event_number"
     if coefficients isa Vector{Float64}
         crunch_for_seconds(alg.runtime, coefficients)
     end

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -65,9 +65,9 @@ end
 
 function notify_graph_finalization(notifications::RemoteChannel, graph_id::Int,
                                    terminating_results...)
-    println("Graph $graph_id: all tasks in the graph finished!")
+    @info "Graph $graph_id: all tasks in the graph finished!"
     put!(notifications, graph_id)
-    println("Graph $graph_id: notified!")
+    @info "Graph $graph_id: notified!"
 end
 
 function is_terminating_alg(graph::AbstractGraph, vertex_id::Int)

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -4,50 +4,50 @@ import DataFrames
 import Plots
 import JSON3
 
-function save_logs(logs, ::String, ::Val{T}) where {T}
+function save_trace(trace, ::String, ::Val{T}) where {T}
     throw(ArgumentError("Unsupported visualization mode: `$T`"))
 end
 
-function save_logs(logs, path::String, mode::Symbol)
-    return save_logs(logs, path, Val{mode}())
+function save_trace(trace, path::String, mode::Symbol)
+    return save_trace(trace, path, Val{mode}())
 end
 
-function save_logs(logs, path::String, ::Val{:graph})
+function save_trace(trace, path::String, ::Val{:graph})
     if splitext(path)[2] == ".dot"
         open(path, "w") do io
-            Dagger.show_logs(io, logs, :graphviz; color_by = :proc)
-            @info "Written logs dot graph to $path"
+            Dagger.show_logs(io, trace, :graphviz; color_by = :proc)
+            @info "Written trace dot graph to $path"
         end
     else
-        graphviz = Dagger.render_logs(logs, :graphviz; color_by = :proc)
+        graphviz = Dagger.render_logs(trace, :graphviz; color_by = :proc)
         FileIO.save(path, graphviz)
-        @info "Written logs graph to $path"
+        @info "Written trace graph to $path"
     end
 end
 
-function save_logs(logs, path::String, ::Val{:trace})
+function save_trace(trace, path::String, ::Val{:chrome})
     open(path, "w") do io
-        Dagger.show_logs(io, logs, :chrome_trace)
-        @info "Written logs trace to $path"
+        Dagger.show_logs(io, trace, :chrome_trace)
+        @info "Written chrome trace to $path"
     end
 end
 
-function save_logs(logs, path::String, ::Val{:gantt})
-    plot = Dagger.render_logs(logs, :plots_gantt)
+function save_trace(trace, path::String, ::Val{:gantt})
+    plot = Dagger.render_logs(trace, :plots_gantt)
     Plots.savefig(plot, path)
-    @info "Written logs gantt chart to $path"
+    @info "Written trace gantt chart to $path"
 end
 
-function save_logs(logs, path::String, ::Val{:raw})
+function save_trace(trace, path::String, ::Val{:raw})
     if splitext(path)[2] == ".json"
         open(path, "w") do io
-            JSON3.write(io, logs)
-            @info "Written raw json logs to $path"
+            JSON3.write(io, trace)
+            @info "Written raw json trace to $path"
         end
     else
         open(path, "w") do io
-            println(io, logs)
-            @info "Written raw logs to $path"
+            println(io, trace)
+            @info "Written raw trace to $path"
         end
     end
 end

--- a/test/demo_workflows.jl
+++ b/test/demo_workflows.jl
@@ -14,7 +14,7 @@ function run_demo(name::String, coefficients::Union{Dagger.Shard, Nothing})
 end
 
 @testset "Demo workflows" begin
-    FrameworkDemo.disable_logging!()
+    FrameworkDemo.disable_tracing!()
     is_fast = "no-fast" ∉ ARGS
     coefficients = FrameworkDemo.calibrate_crunch(; fast = is_fast)
     run(name) = run_demo(name, coefficients)

--- a/test/demo_workflows.jl
+++ b/test/demo_workflows.jl
@@ -1,6 +1,7 @@
 using FrameworkDemo
 using Test
 using Dagger
+using Logging
 
 function run_demo(name::String, coefficients::Union{Dagger.Shard, Nothing})
     @testset "$name" begin
@@ -9,7 +10,8 @@ function run_demo(name::String, coefficients::Union{Dagger.Shard, Nothing})
         graph = FrameworkDemo.parse_graphml(path)
         df = FrameworkDemo.mockup_dataflow(graph)
         event = FrameworkDemo.Event(df)
-        @test_nowarn wait.(FrameworkDemo.schedule_graph!(event, coefficients))
+        @test_logs min_level=Logging.Warn wait.(FrameworkDemo.schedule_graph!(event,
+                                                                              coefficients))
     end
 end
 

--- a/test/scheduling.jl
+++ b/test/scheduling.jl
@@ -49,14 +49,14 @@ end
     event = FrameworkDemo.Event(df)
 
     Dagger.enable_logging!(tasknames = true, taskdeps = true)
-    _ = FrameworkDemo.fetch_logs!() # flush logs
+    _ = FrameworkDemo.fetch_trace!() # flush
 
     tasks = FrameworkDemo.schedule_graph!(event, coefficients)
     wait.(tasks)
 
-    logs = FrameworkDemo.fetch_logs!()
-    FrameworkDemo.disable_logging!()
-    @test !isnothing(logs)
+    trace = FrameworkDemo.fetch_trace!()
+    FrameworkDemo.disable_tracing!()
+    @test !isnothing(trace)
 
     task_to_tid = lock(Dagger.Sch.EAGER_ID_MAP) do id_map
         return deepcopy(id_map)
@@ -68,7 +68,7 @@ end
     end
 
     @testset "Timeline" begin
-        timeline = get_alg_timeline(logs)
+        timeline = get_alg_timeline(trace)
         @test length(timeline) == algorithms_count
 
         get_time = (node_id) -> timeline[get_tid(node_id)]
@@ -83,7 +83,7 @@ end
     end
 
     @testset "Dependencies" begin
-        deps = get_alg_deps(logs)
+        deps = get_alg_deps(trace)
         get_deps = node_id -> deps[get_tid(node_id)]
 
         @test get_tid("ProducerA") ∈ get_deps("TransformerAB")

--- a/test/visualization.jl
+++ b/test/visualization.jl
@@ -22,8 +22,8 @@ using MetaGraphs
         @test has_edge("TransformerAB", "ConsumerCD")
     end
 
-    @testset "Save logs" begin
-        @test_throws ArgumentError FrameworkDemo.save_logs(Dict{}(), tempname(),
-                                                           :unsupported_format)
+    @testset "Save trace" begin
+        @test_throws ArgumentError FrameworkDemo.save_trace(Dict{}(), tempname(),
+                                                            :unsupported_format)
     end
 end


### PR DESCRIPTION
BEGINRELEASENOTES
- Refer to obtaining Dagger execution logs as trace and reserve name logging for "log" printouts

ENDRELEASENOTES

Previously we used name logs for both printouts like `@info` as well as dagger execution information (for instance`Dagger.fetch_logs!()`). Here I rename dagger execution information logs to traces  and reserve name logs only for printout logging with `@info` and other macros. 

This also incorporates a fix from @SmalRat to replace all `println` inside scheduler and mockup algorithms with logging macros. This way all the logging can be easily redirected to some sink or the information can be filtered with appropriate log-level