### PR TITLE
add citation file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,32 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: FrameworkDemo.jl
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Mateusz Jakub
+    family-names: Fila
+    affiliation: CERN
+    orcid: 'https://orcid.org/0000-0003-3917-2371'
+    email: mateusz.jakub.fila@cern.ch
+  - given-names: Benedikt
+    family-names: Hegner
+    email: Benedikt.Hegner@cern.ch
+    orcid: 'https://orcid.org/0009-0009-2020-1620'
+    affiliation: CERN
+  - given-names: Oleksandr
+    affiliation: Ukrainian Catholic University
+    family-names: Shchur
+  - given-names: Josh
+    family-names: Ott
+    orcid: 'https://orcid.org/0000-0002-4893-5484'
+    affiliation: North Carolina State University
+repository-code: 'https://github.com/key4hep/key4hep-julia-fwk'
+abstract: >-
+  Demonstrator project for HEP event-processing application
+  framework in Julia and using Dagger.jl
+license: Apache-2.0


### PR DESCRIPTION
BEGINRELEASENOTES
- Add citation file

ENDRELEASENOTES

The project is referenced in some raports, articles and theses, getting a citation from github should simplify preparing bibliography.
Later we can add citation to the proceedings with [preferred-citation](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#credit-redirection).