### PR TITLE
Add plotting durations from chrome trace, more histogram options

### DIFF
--- a/tools/Project.toml
+++ b/tools/Project.toml
@@ -3,11 +3,15 @@ ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 GraphMLReader = "8e6830a9-644c-4485-8539-40ee18e3ca8c"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[sources]
+GraphMLReader = {rev = "master", url = "https://github.com/SmalRat/GraphMLReader.jl"}
 
 [compat]
 ArgParse = "1.2"
@@ -20,6 +24,3 @@ Plots = "1.40"
 Printf = "1.11"
 Statistics = "1.11"
 julia = "1.11"
-
-[sources]
-GraphMLReader = {rev = "master", url = "https://github.com/SmalRat/GraphMLReader.jl"}


### PR DESCRIPTION
BEGINRELEASENOTES
- Add plotting duration distribution from chrome trace
- Add arguments to specify minimum, maximum and number of bins in duration histogram

ENDRELEASENOTES

So far it was only possible to plot distributions of algorithm durations from the dataflow graphs or Gaudi timeline csv. This add possibility to plot also from chrome trace so there is a convenient way to visualize the execution trace

also adding arguments for some basic histogram configuration so different plots can use the same user-defined axis