### PR TITLE
Add disabling logs, setting crunching coefficients from cli

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,13 +13,13 @@ GraphMLReader = "8e6830a9-644c-4485-8539-40ee18e3ca8c"
 GraphViz = "f526b714-d49f-11e8-06ff-31ed36ee7ee0"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
-[sources.GraphMLReader]
-rev = "master"
-url = "https://github.com/SmalRat/GraphMLReader.jl"
+[sources]
+GraphMLReader = {rev = "master", url = "https://github.com/SmalRat/GraphMLReader.jl"}
 
 [compat]
 Aqua = "0.8"

--- a/bin/schedule.jl
+++ b/bin/schedule.jl
@@ -60,13 +60,13 @@ function parse_args(raw_args)
         arg_type = String
 
         "--crunch-coefficients"
-        help = "Set the crunching coefficients manually. Must be a 2-element vector. Conflicts with --fast"
+        help = "Set the CPU-crunching coefficients manually. Must be a 2-element vector. Each process will use the same values. Conflicts with --fast"
         arg_type = Float64
         nargs = 2
     end
 
     parsed = ArgParse.parse_args(raw_args, s)
-    if !isnothing(parsed["crunch-coefficients"]) && parsed["fast"]
+    if !isempty(parsed["crunch-coefficients"]) && parsed["fast"]
         error("--fast and --crunch-coefficients are mutually exclusive")
     end
     return parsed
@@ -112,9 +112,9 @@ function (@main)(raw_args)
         return
     end
 
-    if !isnothing(args["crunch-coefficients"])
+    if !isempty(args["crunch-coefficients"])
         coefs = args["crunch-coefficients"]
-        @info "Using in each worker the provided crunching coefficients: $coefs"
+        @info "Using provided CPU-crunching coefficients: $coefs"
         crunch_coefficients = Dagger.@shard coefs
     else
         crunch_coefficients = FrameworkDemo.calibrate_crunch(; fast = fast)

--- a/src/cpu_crunching.jl
+++ b/src/cpu_crunching.jl
@@ -33,7 +33,9 @@ function calculate_coefficients(min = 1000, max = 200_000)::Vector{Float64}
     n_max = [min, max]
     t_average = benchmark_prime.(n_max)
 
-    return inv([n_max[i]^j for i in 1:2, j in 1:2]) * t_average
+    coefficients = inv([n_max[i]^j for i in 1:2, j in 1:2]) * t_average
+    @info "Calibrated crunching coefficients: $coefficients"
+    return coefficients
 end
 
 function crunch_for_seconds(t::Float64, coefficients::Vector{Float64})


### PR DESCRIPTION
BEGINRELEASENOTES
- Add option to globally disable logging in `schedule.jl`. Add option to set  user-provided crunching coefficient in `schedule.jl`
- Log effects of CPU-crunching calibration so they can be saved and reproduced.
ENDRELEASENOTES 

This adds a convenient CLI argument to globally disable logging below certain level in the `schedule.jl`. This is different than setting global logger with minimal loglevel, as still some parts might use the global logger but the rest use their own specific loggers. This setting should disable all the loggers.

Also previously the CPU-crunching had to be calculated each time without a possibility to provide crunching coefficients by hand. While in general crunching should be done dynamically as it takes into account the current load on a processor, an option to use user-provided coefficient is helpful for debugging and verifying reproducibility
Also now the CPU-crunching calibration with log the resulting coefficients 