### PR TITLE
Add warm-up events in launcher

### DIFF
--- a/bin/schedule.jl
+++ b/bin/schedule.jl
@@ -132,6 +132,17 @@ function (@main)(raw_args)
                                                    event_count = warmup_count,
                                                    max_concurrent = max_concurrent,
                                                    crunch_coefficients = crunch_coefficients)
+        if tracing_required
+            trace = FrameworkDemo.fetch_trace!()
+            for format in trace_formats
+                path = args["trace-$format"]
+                if !isnothing(path)
+                    base, ext = splitext(path)
+                    warmup_path = base * "_warmup" * ext
+                    FrameworkDemo.save_trace(trace, warmup_path, Symbol(format))
+                end
+            end
+        end
     end
 
     @info "Pipeline: processing $event_count events"


### PR DESCRIPTION
BEGINRELEASENOTES
- Add options to run warm-up events before the proper pipeline. Warm-up events aren't included in the timing. If tracing is enabled the warm-up events and cpu-crunching will be saved together to a separate trace

ENDRELEASENOTES

Adding `warmup-count` option to schedule warm-up events before pipeline. That should allow to move most in not all compilation to the warmup phase.
If tracing is enabled cpu-crunching and trace-events will be saved to a separate trace with `_warmup` appended to the filename stem -> crunch calibration will stop appearing in the main trace