### PR TITLE
fix aqua checks

### DIFF
--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -5,6 +5,5 @@ using Aqua
 @testset "Aqua.jl" begin
     Aqua.test_all(FrameworkDemo;
                   ambiguities = false,
-                  stale_deps = (; ignore = [:ArgParse]),# bin/
-                  persistent_tasks = (; broken = true)) # GraphMLReader [8e6830a9] has no known versions!
+                  stale_deps = (; ignore = [:ArgParse]),) # bin/
 end


### PR DESCRIPTION
BEGINRELEASENOTES
- Removed unneeded aqua check for `persistent_tasks`

ENDRELEASENOTES

Previously aqua test for `persistent_tasks` was broken for `GraphMLReader`. Currently it seems to be correctly resolved while aqua still expects it be broken