### PR TITLE
Add repeating pipeline and saving timing information

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 Dagger = "d58978e5-989f-55fb-8d15-ea34adc7bf54"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
@@ -24,6 +25,7 @@ GraphMLReader = {rev = "master", url = "https://github.com/SmalRat/GraphMLReader
 [compat]
 Aqua = "0.8"
 ArgParse = "1.2"
+CSV = "0.10"
 Dagger = "0.18.13"
 DataFrames = "1.6"
 Distributed = "1.11"

--- a/bin/schedule.jl
+++ b/bin/schedule.jl
@@ -72,7 +72,7 @@ function parse_args(raw_args)
         arg_type = Float64
         nargs = 2
 
-        "--timing-file"
+        "--save-timing"
         help = "Output the timing information. Must be a csv file"
         arg_type = String
 
@@ -217,8 +217,8 @@ function (@main)(raw_args)
         println(select(df, Not([:threads, :event_count, :max_concurrent, :coefs])))
     end
 
-    if !isnothing(args["timing-file"])
-        path = args["timing-file"]
+    if !isnothing(args["save-timing"])
+        path = args["save-timing"]
         CSV.write(path, df)
         @info "Written timing information to $path"
     end

--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -5,5 +5,5 @@ using Aqua
 @testset "Aqua.jl" begin
     Aqua.test_all(FrameworkDemo;
                   ambiguities = false,
-                  stale_deps = (; ignore = [:ArgParse]),) # bin/
+                  stale_deps = (; ignore = [:ArgParse, :CSV]),) # bin/
 end


### PR DESCRIPTION
BEGINRELEASENOTES
- Add `--trials` option to `schedule.jl` to repeat pipeline multiple times. Add `--save-timing` option to save timing information to a csv file

ENDRELEASENOTES

Adding scheduling the main pipeline multiple times, measuring the timing information and putting it in a csv file which can be stored to csv. Also adding more control to the pipeline timing printouts. This should it make easier to make and store performance measurements

For know saving timing doesn't include configuration of remote workers