### PR TITLE
Add scripts for measuring and plotting throughput

### DIFF
--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,9 +1,17 @@
 [deps]
+ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 FrameworkDemo = "cfbf7e84-66d2-421e-b147-9edb7a8672d2"
+GraphMLReader = "8e6830a9-644c-4485-8539-40ee18e3ca8c"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-GraphMLReader = "8e6830a9-644c-4485-8539-40ee18e3ca8c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[sources]
+FrameworkDemo = {path = ".."}
+GraphMLReader = {rev = "master", url = "https://github.com/SmalRat/GraphMLReader.jl"}
 
 [compat]
 BenchmarkTools = "1.5"
@@ -12,7 +20,3 @@ GraphMLReader = "0.1"
 Plots = "1.40"
 Printf = "1.11"
 julia = "1.11"
-
-[sources]
-FrameworkDemo = {path = ".."}
-GraphMLReader = {rev = "master", url = "https://github.com/SmalRat/GraphMLReader.jl"}

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -53,4 +53,10 @@ The script will run the executable and save the results in a CSV file for each t
 ./benchmark/throughput.sh
 ```
 
-The benchmark can be adjusted by modifying the script. Requires `numactl`
+The benchmark configuration can be adjusted by modifying the script. Requires `numactl`.
+
+A basic set of plots can be drawn from the outputted CSV files with [`benchmark/throughput_vis.jl`](throughput_vis.jl):
+
+```sh
+julia --project=benchmark benchmark/throughput_viz.jl timing_*.csv
+```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -42,4 +42,15 @@ end
 push!(result_processors, plot_foo) # register function
 ```
 
-The functions added to `results_processors` will be called automatically when executing `benchmark/benchmarks.jl` script. Alternatively the functions can be added with `postprocess`argument of `PkgBenchmark.benchmarkpkg`. 
+The functions added to `results_processors` will be called automatically when executing `benchmark/benchmarks.jl` script. Alternatively the functions can be added with `postprocess`argument of `PkgBenchmark.benchmarkpkg`.
+
+# Throughput benchmarks
+
+The throughput benchmarks don't integrate with the rest of the benchmarks and are run with a standalone bash script [`benchmark/throughput.sh`](throughput.sh).
+The script will run the executable and save the results in a CSV file for each thread pool size.
+
+```sh
+./benchmark/throughput.sh
+```
+
+The benchmark can be adjusted by modifying the script. Requires `numactl`

--- a/benchmark/throughput.sh
+++ b/benchmark/throughput.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+WORKFLOW="$(dirname $0)/../data/ATLAS/q449/df.graphml"
+REPEAT=2
+AFFINITY=0
+THREADS_SEQ="2 4"
+
+THREADS_PER_SLOT=2
+EVENTS_PER_SLOT=2
+
+PROJECT="$(dirname $0)/.."
+EXEC="$(dirname $0)/../bin/schedule.jl"
+
+for threads in ${THREADS_SEQ}; do
+    concurrent=$((threads/THREADS_PER_SLOT))
+    total=$((concurrent*EVENTS_PER_SLOT))
+    output_file="timing_${threads}.csv"
+    echo "Starting measurements for ${threads} threads, ${total} total events," \
+        "${concurrent} concurrent events"
+    CMD=(
+      numactl --cpunodebind="${AFFINITY}" --membind="${AFFINITY}" julia -t "${threads}"
+      --project="${PROJECT}" "${EXEC}" "${WORKFLOW}" --disable-logging=warn
+      --max-concurrent="${concurrent}" --event-count="${total}"
+      --warmup-count="${total}" --trials="${REPEAT}" --save-timing="${output_file}"
+    )
+    CMD=${CMD[*]}
+    echo "Running command: ${CMD}"
+    $CMD
+done

--- a/benchmark/throughput_vis.jl
+++ b/benchmark/throughput_vis.jl
@@ -1,0 +1,88 @@
+using Plots
+using CSV
+using DataFrames
+using ArgParse
+using Statistics
+
+function parse_args(args)
+    s = ArgParseSettings(description = "Visualize the throughput from timing CSV files")
+    @add_arg_table! s begin
+        "input"
+        help = "Input timing CSV file"
+        arg_type = String
+        nargs = '+'
+        required = true
+
+        "--t-min"
+        help = "Minimum number of threads"
+        arg_type = Int
+
+        "--t-max"
+        help = "Maximum number of threads"
+        arg_type = Int
+
+        "--no-scale"
+        help = "Do not include comparison with linear scaling for throughput"
+        action = :store_true
+
+        "--median"
+        help = "Use median instead of minimum for throughput"
+        action = :store_true
+    end
+
+    return ArgParse.parse_args(args, s)
+end
+
+function (@main)(args)
+    parsed_args = parse_args(args)
+    metric = parsed_args["median"] ? median : minimum
+    @info "Using metric: $(metric)"
+
+    df = vcat(map(file -> DataFrame(CSV.File(file)), parsed_args["input"])...)
+    df.gctime_percent = 100 * df.gctime ./ df.time
+    gdf = groupby(df, [:threads, :event_count, :max_concurrent])
+    cols = [:time, :throughput, :gctime_percent]
+    df = combine(gdf, cols .=> metric .=> (col -> Symbol(col, "_metric")))
+    df = sort(df, [:threads, :event_count, :max_concurrent])
+    println("DataFrame: ", df)
+
+    if (!isnothing(parsed_args["t-min"]))
+        filter!(row -> row.threads >= parsed_args["t-min"], df)
+    end
+    if (!isnothing(parsed_args["t-max"]))
+        filter!(row -> row.threads <= parsed_args["t-max"], df)
+    end
+
+    df.perfect_scaling = (df.threads) .* (df.throughput_metric[1]) / (df.threads[1])
+
+    output_file = "throughput.png"
+    series = [df.throughput_metric]
+    labels = ["Measured"]
+    if !parsed_args["no-scale"]
+        push!(series, df.perfect_scaling)
+        push!(labels, "Linear scaling")
+    end
+    plot(df.threads, series, labels = hcat(labels...),
+         title = "Throughput scaling", xlabel = "Number of threads",
+         ylabel = "Throughput (events/s)", marker = (:circle, 5), linewidth = 3,
+         xguidefonthalign = :right, yguidefontvalign = :top)
+    savefig(output_file)
+    @info "Saved plot to $output_file"
+
+    output_file = "ratio.png"
+    plot(df.threads, df.throughput_metric ./ df.perfect_scaling, label = "Ratio",
+         title = "Throughput per thread scaling", xlabel = "Number of threads",
+         ylabel = "Throughput per thread ratio", marker = (:circle, 5), linewidth = 3,
+         xguidefonthalign = :right, yguidefontvalign = :top)
+    savefig(output_file)
+    @info "Saved plot to $output_file"
+
+    output_file = "gc.png"
+    plot(df.threads, df.gctime_percent_metric, label = "GC time",
+         title = "Garbage collection time", xlabel = "Number of threads",
+         ylabel = "GC time (%)", marker = (:circle, 5), linewidth = 3,
+         xguidefonthalign = :right, yguidefontvalign = :top)
+    savefig(output_file)
+    @info "Saved plot to $output_file"
+    return 0
+end


### PR DESCRIPTION
BEGINRELEASENOTES
- Add simple script for measuring throughput and another script to make plots

ENDRELEASENOTES

Adding simple bash script that runs `schedule.jl` with different number of threads and saves the timing information to CSV. The csv can be later plotted with another julia script
