### PR TITLE
Fix code changing with formatter v1 and v2

### DIFF
--- a/test/visualization.jl
+++ b/test/visualization.jl
@@ -11,8 +11,7 @@ using MetaGraphs
 
         @test nv(graph) == 7
         @test ne(graph) == 7
-        has_edge(x::String, y::String) = Graphs.has_edge(graph, graph[x, :label],
-                                                         graph[y, :label])
+        has_edge(x, y) = Graphs.has_edge(graph, graph[x, :label], graph[y, :label])
         @test has_edge("ProducerA", "TransformerAB")
         @test has_edge("ProducerBC", "TransformerAB")
         @test has_edge("ProducerBC", "ConsumerBC")


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix code that was formatted differently with JuliaFormatter v1 and  v2

ENDRELEASENOTES

JuliaFormatter v2 has slightly different formatting than v1. In our case this affects only one function. For now the CI and  `tools` will still use v1 as most of the tooling (IDEs) is still using v1 (and not providing any config to control this)