### PR TITLE
Housekeeping: remove redundant return casts, add missing const

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -2,8 +2,8 @@ using FrameworkDemo
 using BenchmarkTools
 using Plots
 
-SUITE = BenchmarkGroup()
-result_processors = Function[]
+const SUITE = BenchmarkGroup()
+const result_processors = Function[]
 
 include("suite/cpu_crunching.jl")
 

--- a/benchmark/throughput.sh
+++ b/benchmark/throughput.sh
@@ -5,7 +5,7 @@ AFFINITY=0
 THREADS_SEQ="2 4"
 
 THREADS_PER_SLOT=2
-EVENTS_PER_SLOT=2
+EVENTS_PER_SLOT=20
 
 PROJECT="$(dirname $0)/.."
 EXEC="$(dirname $0)/../bin/schedule.jl"

--- a/src/cpu_crunching.jl
+++ b/src/cpu_crunching.jl
@@ -29,7 +29,10 @@ function benchmark_prime(n::Int)
     return Δt
 end
 
-function calculate_coefficients(min = 1000, max = 200_000)::Vector{Float64}
+"""
+    calculate_coefficients(min, max) -> Vector{Float64}
+"""
+function calculate_coefficients(min = 1000, max = 200_000)
     n_max = [min, max]
     t_average = benchmark_prime.(n_max)
 

--- a/src/mockup.jl
+++ b/src/mockup.jl
@@ -34,7 +34,10 @@ function get_name(alg::MockupAlgorithm)
     return alg.name
 end
 
-function mockup_dataflow(graph::MetaDiGraph)::DataFlowGraph
+"""
+    mockup_dataflow(graph::MetaDiGraph) -> DataFlowGraph
+"""
+function mockup_dataflow(graph::MetaDiGraph)
     data_flow = DataFlowGraph(graph)
     for i in data_flow.algorithm_indices
         alg = MockupAlgorithm(data_flow, i)

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -11,7 +11,10 @@ function encode_ids!(g)
     end
 end
 
-function parse_graphml(filename::String)::MetaDiGraph
+"""
+    parse_graphml(filename::String) -> MetaDiGraph
+"""
+function parse_graphml(filename::String)
     g = GraphMLReader.loadgraphml(filename, "G")
     encode_ids!(g)
     return g

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -43,7 +43,10 @@ struct DataFlowGraph
     end
 end
 
-function get_algorithm(data_flow::DataFlowGraph, index::Int)::AbstractAlgorithm
+"""
+    get_algorithm(data_flow::DataFlowGraph, index::Int) -> AbstractAlgorithm
+"""
+function get_algorithm(data_flow::DataFlowGraph, index::Int)
     return get_prop(data_flow.graph, index, :algorithm)
 end
 
@@ -56,11 +59,17 @@ struct Event
     end
 end
 
+"""
+    put_result!(event::Event, index::Int, result::Dagger.DTask) -> Dagger.DTask
+"""
 function put_result!(event::Event, index::Int, result::Dagger.DTask)
     return event.store[index] = result
 end
 
-function get_result(event::Event, index::Int)::Dagger.DTask
+"""
+    get_result(event::Event, index::Int) -> Dagger.DTask
+"""
+function get_result(event::Event, index::Int)
     return event.store[index]
 end
 
@@ -110,8 +119,10 @@ function schedule_graph!(event::Event, coefficients::Union{Dagger.Shard, Nothing
     return terminating_results
 end
 
-function calibrate_crunch(min::Int = 1000, max::Int = 200_000;
-                          fast::Bool = false)::Union{Dagger.Shard, Nothing}
+"""
+    calibrate_crunch(min::Int = 1000, max::Int = 200_000; fast::Bool = false) -> Union{Dagger.Shard, Nothing}
+"""
+function calibrate_crunch(min::Int = 1000, max::Int = 200_000; fast::Bool = false)
     return fast ? nothing : Dagger.@shard calculate_coefficients(min, max)
 end
 

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -52,7 +52,10 @@ function save_trace(trace, path::String, ::Val{:raw})
     end
 end
 
-function get_execution_plan(df::DataFlowGraph)::MetaDiGraph
+"""
+    get_execution_plan(df::DataFlowGraph) -> MetaDiGraph
+"""
+function get_execution_plan(df::DataFlowGraph)
     g = MetaDiGraph()
     for (i, v) in enumerate(df.algorithm_indices)
         add_vertex!(g)

--- a/test/scheduling.jl
+++ b/test/scheduling.jl
@@ -62,7 +62,7 @@ end
         return deepcopy(id_map)
     end
 
-    function get_tid(node_id::String)::Int
+    function get_tid(node_id::String)
         task = FrameworkDemo.get_result(event, graph[node_id, :node_id])
         return task_to_tid[task.uid]
     end


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove redunant return casts for functions
- Add missing `cost` in benchmark
- Changed the defaults in `throughput.sh` to be more useful

ENDRELEASENOTES

Collection of small houskeeping improvements