### PR TITLE
Add option to disable MemPool automatic GC

### DIFF
--- a/bin/schedule.jl
+++ b/bin/schedule.jl
@@ -90,6 +90,10 @@ function parse_args(raw_args)
         help = "Scale factor to apply to the duration of each algorithm"
         arg_type = Float64
         default = 1.0
+
+        "--disable-mempool-gc"
+        help = "Disable MemPool automatic GC. Use to reduce the GC time on systems with low memory (laptop)"
+        action = :store_true
     end
 
     parsed = ArgParse.parse_args(raw_args, s)
@@ -154,6 +158,11 @@ function (@main)(raw_args)
 
     if !isnothing(args["disable-logging"])
         disable_logging(args["disable-logging"])
+    end
+
+    if args["disable-mempool-gc"]
+        Dagger.MemPool.MEM_RESERVED[] = 0
+        @info "Disabled MemPool automatic GC"
     end
 
     tracing_required = any(x -> !isnothing(args["trace-$x"]), trace_formats)


### PR DESCRIPTION
BEGINRELEASENOTES
- Add option in `schedule.jl` to disable Dagger's MemPool automatic GC, useful to reduce GC time on systems with low memory (laptop)

ENDRELEASENOTES

Thank you @jpsamaroo for this insight 