### PR TITLE
disable collecting metrics in dagger logging

### DIFF
--- a/src/logging.jl
+++ b/src/logging.jl
@@ -8,7 +8,8 @@ function enable_tracing!()
                            taskargmoves = true,
                            taskresult = true,
                            taskuidtotid = true,
-                           tasktochunk = true)
+                           tasktochunk = true,
+                           metrics = false)
 end
 
 function disable_tracing!()


### PR DESCRIPTION
BEGINRELEASENOTES
- Disable collecting metrics in Dagger logging to avoid slow downs

ENDRELEASENOTES

Collecting trace with Dagger with the default `metrics=true`was introducing massive overheads. JuliaParallel/Dagger.jl#621

Without trace:
```
julia -t 8 --project bin/schedule.jl data/ATLAS/q449/df.graphml --max-concurrent 4 --event-count 40 --warmup-count 8 --disable-loggin warn
Pipeline (throughput 1.00 events/s): 40.097314 seconds (62.55 M allocations: 3.252 GiB, 3.20% gc time, 128376 lock conflicts, 0.47% compilation time)
```

With trace (> 600% slow down):
```
julia -t 8 --project bin/schedule.jl data/ATLAS/q449/df.graphml --max-concurrent 4 --event-count 40 --warmup-count 8 --disable-loggin warn --trace-chrome=trace.json
Pipeline (throughput 0.14 events/s): 290.967248 seconds (233.25 M allocations: 19.686 GiB, 4.86% gc time, 3346075 lock conflicts, 0.00% compilation time)
```

With trace and `metrics=false` (40% slow down)
```
julia -t 8 --project bin/schedule.jl data/ATLAS/q449/df.graphml --max-concurrent 4 --event-count 40 --warmup-count 8 --disable-loggin warn --trace-chrome=trace.json
Pipeline (throughput 0.71 events/s): 56.636791 seconds (106.55 M allocations: 8.984 GiB, 7.98% gc time, 1045838 lock conflicts, 0.00% compilation time)
```
