### PR TITLE
add manual scheduling

### DIFF
--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -1,15 +1,9 @@
-import Dagger
 using MetaGraphs
-import Preferences
-if Preferences.@load_preference("distributed-package") == "DistributedNext"
-    using DistributedNext
-else
-    using Distributed
-end
+using Base.Threads
 import NVTX
-import Colors
+using Colors
 
-const nvtx_colors = Colors.distinguishable_colors(32)
+nvtx_color = Colors.distinguishable_colors(32)
 
 abstract type AbstractAlgorithm end
 
@@ -27,10 +21,9 @@ struct BoundAlgorithm{T <: AbstractAlgorithm}
     event_number::Int
 end
 
-NVTX.@annotate get_name(algorithm) color=nvtx_colors[mod1(algorithm.event_number,
-                                                          length(nvtx_colors))] payload=algorithm.event_number function (algorithm::BoundAlgorithm)(data...;
-                                                                                                                                                    coefficients::Union{Vector{Float64},
-                                                                                                                                                                        Missing})
+NVTX.@annotate get_name(algorithm) color=nvtx_color[mod1(algorithm.event_number, 32)] payload=algorithm.event_number function (algorithm::BoundAlgorithm)(data...;
+                                                                                                                                                          coefficients::Union{Vector{Float64},
+                                                                                                                                                                              Missing})
     return algorithm.alg(data...; event_number = algorithm.event_number,
                          coefficients = coefficients)
 end
@@ -43,10 +36,10 @@ struct DataFlowGraph
     graph::MetaDiGraph{Int, Float64}
     algorithm_indices::Vector{Int}
     function DataFlowGraph(graph::MetaDiGraph)
-        alg_vertices = MetaGraphs.filter_vertices(graph, :type, "Algorithm")
+        algo_vertices = MetaGraphs.filter_vertices(graph, :type, "Algorithm")
         sorted_vertices = MetaGraphs.topological_sort(graph)
-        sorted_alg_vertices = intersect(sorted_vertices, alg_vertices)
-        new(graph, sorted_alg_vertices)
+        sorted_algo_vertices = intersect(sorted_vertices, algo_vertices)
+        new(graph, sorted_algo_vertices)
     end
 end
 
@@ -54,20 +47,22 @@ function get_algorithm(data_flow::DataFlowGraph, index::Int)::AbstractAlgorithm
     return get_prop(data_flow.graph, index, :algorithm)
 end
 
+# removed Dagger.DTask
 struct Event
     data_flow::DataFlowGraph
-    store::Dict{Int, Dagger.DTask}
+    store::Dict{Int, Any}
     event_number::Int
     function Event(data_flow::DataFlowGraph, event_number::Int = 0)
-        new(data_flow, Dict{Int, Dagger.DTask}(), event_number)
+        new(data_flow, Dict{Int, Any}(), event_number)
     end
 end
 
-function put_result!(event::Event, index::Int, result::Dagger.DTask)
+# removed Dagger.DTask
+function put_result!(event::Event, index::Int, result::Any)
     return event.store[index] = result
 end
 
-function get_result(event::Event, index::Int)::Dagger.DTask
+function get_result(event::Event, index::Int)::Any
     return event.store[index]
 end
 
@@ -75,7 +70,7 @@ function get_results(event::Event, vertices::Vector{Int})
     return get_result.(Ref(event), vertices)
 end
 
-function notify_graph_finalization(notifications::RemoteChannel, graph_id::Int,
+function notify_graph_finalization(notifications::Channel{Int}, graph_id::Int, # RemoteChannel to Channel{Int}
                                    terminating_results...)
     @info "Graph $graph_id: all tasks in the graph finished!"
     put!(notifications, graph_id)
@@ -88,63 +83,191 @@ function is_terminating_alg(graph::AbstractGraph, vertex_id::Int)
     all(is_terminating, successor_dataobjects)
 end
 
+#---------------- Removing Dagger from Scheduling ----------------#
+
+# modified schedule_algorithm for threading
 function schedule_algorithm(event::Event, vertex_id::Int,
-                            coefficients::Union{Dagger.Shard, Nothing})
-    incoming_data = get_results(event, inneighbors(event.data_flow.graph, vertex_id))
+                            coefficients::Union{Any, Nothing},
+                            done_channel::Channel{Tuple{Int, Any}})
+    # get the incoming vertices for this algorithm
+    incoming_vertices = inneighbors(event.data_flow.graph, vertex_id)
+
+    # debug: Check if all incoming data is available
+    for v in incoming_vertices
+        if !haskey(event.store, v)
+            @error "Missing data for vertex $v required by algorithm vertex $vertex_id"
+            @error "Available vertices in store: $(keys(event.store))"
+            @error "Algorithm vertices: $(event.data_flow.algorithm_indices)"
+        end
+    end
+
+    incoming_data = get_results(event, incoming_vertices)
     algorithm = BoundAlgorithm(get_algorithm(event.data_flow, vertex_id),
                                event.event_number)
-    if isnothing(coefficients)
-        alg_helper(data...) = algorithm(data...; coefficients = missing)
-        return Dagger.@spawn name=get_name(algorithm) alg_helper(incoming_data...)
-    else
-        return Dagger.@spawn name=get_name(algorithm) algorithm(incoming_data...;
-                                                                coefficients = coefficients)
+
+    # Use the provided coefficients or missing
+    coeff_to_use = isnothing(coefficients) ? missing : coefficients
+
+    # Spawn the task on a thread
+    Threads.@spawn begin
+        alg_name = get_name(algorithm)
+        @debug "Executing $alg_name (vertex $vertex_id) on thread $(threadid())"
+
+        result = algorithm(incoming_data...; coefficients = coeff_to_use)
+        put!(done_channel, (vertex_id, result))
     end
 end
 
-function schedule_graph!(event::Event, coefficients::Union{Dagger.Shard, Nothing})
-    terminating_results = Dagger.DTask[]
-    for vertex_id in event.data_flow.algorithm_indices
-        res = schedule_algorithm(event, vertex_id, coefficients)
-        put_result!(event, vertex_id, res)
-        for v in outneighbors(event.data_flow.graph, vertex_id)
-            put_result!(event, v, res)
-        end
-        is_terminating_alg(event.data_flow.graph, vertex_id) &&
-            push!(terminating_results, res)
+function schedule_graph!(event::Event, coefficients::Union{Any, Nothing})
+    graph = event.data_flow.graph
+    all_vertices = vertices(graph)
+    algo_vertices = event.data_flow.algorithm_indices
+
+    @debug "Running with $(Threads.nthreads()) threads"
+
+    # data vertices (non algo)
+    data_vertices = setdiff(all_vertices, algo_vertices)
+
+    # Initialize all data vertices
+    for v in data_vertices
+        put_result!(event, v, Float64[])
     end
+
+    # dependency tracking
+    algorithm_dependencies = Dict{Int, Set{Int}}()
+    parent_count = Dict{Int, Int}()
+    children = Dict{Int, Vector{Int}}()
+
+    for v in algo_vertices
+        deps = Set{Int}()
+
+        # find all data vertices this algorithm needs
+        data_inputs = filter(d -> d in data_vertices, inneighbors(graph, v))
+
+        # for each data input find which algorithm produces it
+        for data_v in data_inputs
+            # find the algorithm that produces this data
+            producers = filter(p -> p in algo_vertices, inneighbors(graph, data_v))
+            for producer in producers
+                push!(deps, producer)
+            end
+        end
+
+        algorithm_dependencies[v] = deps
+        parent_count[v] = length(deps)
+        children[v] = Int[]
+    end
+
+    # build children relationships
+    for v in algo_vertices
+        for dep in algorithm_dependencies[v]
+            push!(children[dep], v)
+        end
+    end
+
+    # channel to receive completion notifications
+    done_channel = Channel{Tuple{Int, Any}}(length(algo_vertices))
+
+    # track active tasks and terminating results
+    active = 0
+    terminating_results = []
+
+    # spawning a vertex
+    function spawn_vertex(vertex_id)
+        alg_name = get_name(get_algorithm(event.data_flow, vertex_id))
+        @debug "Spawning algorithm $alg_name (vertex $vertex_id) on thread $(threadid())"
+
+        schedule_algorithm(event, vertex_id, coefficients, done_channel)
+    end
+
+    # spawn all vertices without parents
+    for v in algo_vertices
+        if parent_count[v] == 0
+            spawn_vertex(v)
+            active += 1
+        end
+    end
+
+    while active > 0
+        (vertex_id, result) = take!(done_channel)
+        active -= 1
+
+        alg_name = get_name(get_algorithm(event.data_flow, vertex_id))
+        @debug "Completed algorithm $alg_name (vertex $vertex_id) on thread $(threadid())"
+
+        # Store the result in the algorithm vertex
+        put_result!(event, vertex_id, result)
+
+        # Also store in all connected data vertices (algorithm outputs)
+        for data_vertex in outneighbors(graph, vertex_id)
+            if !(data_vertex in algo_vertices)
+                put_result!(event, data_vertex, result)
+            end
+        end
+
+        # Track terminating algorithms
+        if is_terminating_alg(graph, vertex_id)
+            push!(terminating_results, result)
+        end
+
+        # Check algorithm children to see if they're ready
+        for child in children[vertex_id]
+            parent_count[child] -= 1
+            if parent_count[child] == 0
+                spawn_vertex(child)
+                active += 1
+            end
+        end
+    end
+
+    close(done_channel)
 
     return terminating_results
 end
+#----------------------------------------------#
 
+# removed Dagger.Shard by just using Vector
 function calibrate_crunch(min::Int = 1000, max::Int = 200_000;
-                          fast::Bool = false)::Union{Dagger.Shard, Nothing}
-    return fast ? nothing : Dagger.@shard calculate_coefficients(min, max)
+                          fast::Bool = false)::Union{Vector{Float64}, Nothing}
+    return fast ? nothing : calculate_coefficients(min, max)
 end
 
 function run_pipeline(data_flow::DataFlowGraph;
                       event_count::Int,
                       max_concurrent::Int,
-                      crunch_coefficients::Union{Dagger.Shard, Nothing} = nothing,)
-    graphs_tasks = Dict{Int, Dagger.DTask}()
-    notifications = RemoteChannel(() -> Channel{Int}(max_concurrent))
+                      crunch_coefficients::Union{Vector{Float64}, Nothing} = nothing)
 
-    for idx in 1:event_count
-        while length(graphs_tasks) >= max_concurrent
-            finished_graph_id = take!(notifications)
-            delete!(graphs_tasks, finished_graph_id)
-            @info dispatch_end_msg(finished_graph_id)
+    # Create semaphore with max_concurrent permits
+    semaphore = Base.Semaphore(max_concurrent)
+
+    # Store all tasks to wait for completion
+    all_tasks = Task[]
+
+    # run graph in a thread with semaphore control
+    function run_graph_with_semaphore(idx::Int)
+        # Acquire semaphore (blocks if all permits taken)
+        Base.acquire(semaphore)
+
+        try
+            @info dispatch_begin_msg(idx)
+            event = Event(data_flow, idx)
+            terminating_results = schedule_graph!(event, crunch_coefficients)
+            @info dispatch_end_msg(idx)
+            return terminating_results
+        finally
+            # Always release semaphore, even if task fails
+            Base.release(semaphore)
         end
-        event = Event(data_flow, idx)
-        terminating_tasks = FrameworkDemo.schedule_graph!(event, crunch_coefficients)
-        graphs_tasks[idx] = Dagger.@spawn notify_graph_finalization(notifications, idx,
-                                                                    terminating_tasks...)
-
-        @info dispatch_begin_msg(idx)
     end
 
-    for (idx, future) in graphs_tasks
-        wait(future)
-        @info dispatch_end_msg(idx)
+    # Launch ALL events immediately - semaphore controls concurrency
+    for idx in 1:event_count
+        task = Threads.@spawn run_graph_with_semaphore(idx)
+        push!(all_tasks, task)
+    end
+
+    # Wait for all tasks to complete
+    for task in all_tasks
+        wait(task)
     end
 end


### PR DESCRIPTION
BEGINRELEASENOTES
-add new schedule_algorithm function
-add new schedule_graph function
-add base.sephamore logic to run_pipeline
ENDRELEASENOTES

The Dagger.jl scheduling logic has been removed and is replaced by a manual scheduling. This improves the scaling of the throughput and does not crash compared to the dagger-implementation for more threads.
![throughput](https://github.com/user-attachments/assets/20f32782-6d7e-45eb-8d71-1406bddfeab8)

Additionally, the new pipeline partially removes batching gaps observed in the NVTX trace. For the sequential data, the trace nearly looks optimal and does not possess gaps. This is not the case for the ATLAS data, which might be due to the existence of different algorithm lengths.   
