### PR TITLE
add running test ci with pre-releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         version:
           - '1'
+          - 'nightly'
         os:
           - ubuntu-latest
         arch:
@@ -26,6 +27,9 @@ jobs:
         test_args:
           - 'no-fast'
           - 'all'
+        exclude:
+          - version: 'nightly'
+            test_args: 'all'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         version:
           - '1'
-          - 'nightly'
+          - 'pre'
         os:
           - ubuntu-latest
         arch:
@@ -27,9 +27,6 @@ jobs:
         test_args:
           - 'no-fast'
           - 'all'
-        exclude:
-          - version: 'nightly'
-            test_args: 'all'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
BEGINRELEASENOTES
- Add running test with Julia nightlies

ENDRELEASENOTES

Some of the proposed features are using Julia 1.12 pre-release #82, yet we needed some fixes to run 1.12 (JuliaParallel/Dagger.jl#598, https://github.com/m-fila/GraphMLReader.jl/pull/2, https://github.com/m-fila/GraphMLReader.jl/pull/1). Adding tests on pre-releases to detect it earlier