### PR TITLE
run gc before pipeline

### DIFF
--- a/bin/schedule.jl
+++ b/bin/schedule.jl
@@ -135,6 +135,7 @@ function measure_pipeline(data_flow,
                           event_count,
                           max_concurrent,
                           crunch_coefficients, profile = nothing)
+    GC.gc() # clean up previous garbage so it's not cleaned up during pipeline
     @info "Pipeline: processing $event_count events"
     stats = @timed pipeline_harness(data_flow, event_count,
                                     max_concurrent,


### PR DESCRIPTION
BEGINRELEASENOTES
- Add manually invoking garbage collector after measuring the pipeline execution to avoid cleaning memory from setup or other trials during the pipeline

ENDRELEASENOTES


Run GC before pipeline so garbage from warm-up or previous trials isn't collected during the pipeline. This reduces the gc time and also distribution of gc time for multiple trials is more uniform