### PR TITLE
Cache dependencies and dependant algorithms

### DIFF
--- a/src/mockup.jl
+++ b/src/mockup.jl
@@ -3,26 +3,27 @@ using MetaGraphs
 struct MockupAlgorithm <: AbstractAlgorithm
     name::String
     runtime::Float64
-    input_length::UInt
+    output_length::UInt
+    id::Int
     function MockupAlgorithm(data_flow::DataFlowGraph, vertex_id::Int)
         graph = data_flow.graph
         name = get_prop(graph, vertex_id, :node_id)
         runtime = get_prop(graph, vertex_id, :runtime_average_s)
-        inputs = length(inneighbors(graph, vertex_id))
-        new(name, runtime, inputs)
+        outputs = length(outneighbors(graph, vertex_id))
+        new(name, runtime, outputs, vertex_id)
     end
 end
 
 const mockup_alg_default_runtime_s = 0
 
 function (alg::MockupAlgorithm)(args...; event_number::Int,
-                                coefficients::Union{Vector{Float64}, Missing})
+                                coefficients::Union{Vector{Float64}, Nothing})
     @info "Executing $(alg.name) event $event_number"
     if coefficients isa Vector{Float64}
         crunch_for_seconds(alg.runtime, coefficients)
     end
 
-    return alg.name
+    return fill(alg.id, alg.output_length)
 end
 
 function get_name(alg::MockupAlgorithm)

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -7,7 +7,7 @@ const nvtx_colors = Colors.distinguishable_colors(32)
 abstract type AbstractAlgorithm end
 
 function (alg::AbstractAlgorithm)(args...; event_number::Int,
-                                  coefficients::Union{Vector{Float64}, Missing})
+                                  coefficients::Union{Vector{Float64}, Nothing})
     error("Subtypes of AbstractAlgorithm must implement function call")
 end
 
@@ -23,7 +23,7 @@ end
 NVTX.@annotate get_name(algorithm) color=nvtx_colors[mod1(algorithm.event_number,
                                                           length(nvtx_colors))] payload=algorithm.event_number function (algorithm::BoundAlgorithm)(data...;
                                                                                                                                                     coefficients::Union{Vector{Float64},
-                                                                                                                                                                        Missing})
+                                                                                                                                                                        Nothing})
     return algorithm.alg(data...; event_number = algorithm.event_number,
                          coefficients = coefficients)
 end
@@ -39,6 +39,23 @@ struct DataFlowGraph
         alg_vertices = MetaGraphs.filter_vertices(graph, :type, "Algorithm")
         sorted_vertices = MetaGraphs.topological_sort(graph)
         sorted_alg_vertices = intersect(sorted_vertices, alg_vertices)
+        # cache number of algorithm dependencies for each algorithms
+        # and indices of dependant algorithms
+        for v in sorted_alg_vertices
+            set_prop!(graph, v, :deps, 0)
+        end
+        for v in sorted_alg_vertices
+            successor_algs = Vector{Int}()
+            for data_successor in outneighbors(graph, v)
+                successors = outneighbors(graph, data_successor)
+                append!(successor_algs, successors)
+                for alg in successors
+                    deps = get_prop(graph, alg, :deps)
+                    set_prop!(graph, alg, :deps, deps + 1)
+                end
+            end
+            set_prop!(graph, v, :successor_algs, successor_algs)
+        end
         new(graph, sorted_alg_vertices)
     end
 end
@@ -60,6 +77,12 @@ function put_result!(event::Event, index::Int, result::Any)
     return event.store[index] = result
 end
 
+function put_results!(event::Event, indices, results)
+    for (k, v) in zip(indices, results)
+        put_result!(event, k, v)
+    end
+end
+
 function get_result(event::Event, index::Int)::Any
     return event.store[index]
 end
@@ -79,125 +102,49 @@ function schedule_algorithm(event::Event, vertex_id::Int,
                             done_channel::Channel{Tuple{Int, Any}})
     # get the incoming vertices for this algorithm
     incoming_vertices = inneighbors(event.data_flow.graph, vertex_id)
-
-    # debug: Check if all incoming data is available
-    for v in incoming_vertices
-        if !haskey(event.store, v)
-            @error "Missing data for vertex $v required by algorithm vertex $vertex_id"
-            @error "Available vertices in store: $(keys(event.store))"
-            @error "Algorithm vertices: $(event.data_flow.algorithm_indices)"
-        end
-    end
-
     incoming_data = get_results(event, incoming_vertices)
+
     algorithm = BoundAlgorithm(get_algorithm(event.data_flow, vertex_id),
                                event.event_number)
 
-    # Use the provided coefficients or missing
-    coeff_to_use = isnothing(coefficients) ? missing : coefficients
-
-    # Spawn the task on a thread
     Threads.@spawn begin
-        alg_name = get_name(algorithm)
-        @debug "Executing $alg_name (vertex $vertex_id) on thread $(threadid())"
-
-        result = algorithm(incoming_data...; coefficients = coeff_to_use)
-        put!(done_channel, (vertex_id, result))
+        results = algorithm(incoming_data...; coefficients = coefficients)
+        put!(done_channel, (vertex_id, results))
     end
 end
 
 function schedule_graph!(event::Event, coefficients::Union{Any, Nothing})
-    graph = event.data_flow.graph
-    all_vertices = vertices(graph)
+    deps = Dict{Int, Int}()
     algo_vertices = event.data_flow.algorithm_indices
-
-    @debug "Running with $(Threads.nthreads()) threads"
-
-    # data vertices (non algo)
-    data_vertices = setdiff(all_vertices, algo_vertices)
-
-    # Initialize all data vertices
-    for v in data_vertices
-        put_result!(event, v, Float64[])
-    end
-
-    # dependency tracking
-    algorithm_dependencies = Dict{Int, Set{Int}}()
-    parent_count = Dict{Int, Int}()
-    children = Dict{Int, Vector{Int}}()
-
     for v in algo_vertices
-        deps = Set{Int}()
-
-        # find all data vertices this algorithm needs
-        data_inputs = filter(d -> d in data_vertices, inneighbors(graph, v))
-
-        # for each data input find which algorithm produces it
-        for data_v in data_inputs
-            # find the algorithm that produces this data
-            producers = filter(p -> p in algo_vertices, inneighbors(graph, data_v))
-            for producer in producers
-                push!(deps, producer)
-            end
-        end
-
-        algorithm_dependencies[v] = deps
-        parent_count[v] = length(deps)
-        children[v] = Int[]
-    end
-
-    # build children relationships
-    for v in algo_vertices
-        for dep in algorithm_dependencies[v]
-            push!(children[dep], v)
-        end
+        deps[v] = get_prop(event.data_flow.graph, v, :deps)
     end
 
     # channel to receive completion notifications
     done_channel = Channel{Tuple{Int, Any}}(length(algo_vertices))
 
     # track active tasks
-    active = 0
-
-    # spawning a vertex
-    function spawn_vertex(vertex_id)
-        alg_name = get_name(get_algorithm(event.data_flow, vertex_id))
-        @debug "Spawning algorithm $alg_name (vertex $vertex_id) on thread $(threadid())"
-
-        schedule_algorithm(event, vertex_id, coefficients, done_channel)
-    end
+    algs_in_flight = 0
 
     # spawn all vertices without parents
     for v in algo_vertices
-        if parent_count[v] == 0
-            spawn_vertex(v)
-            active += 1
+        if deps[v] == 0
+            schedule_algorithm(event, v, coefficients, done_channel)
+            algs_in_flight += 1
         end
     end
 
-    while active > 0
-        (vertex_id, result) = take!(done_channel)
-        active -= 1
-
-        alg_name = get_name(get_algorithm(event.data_flow, vertex_id))
-        @debug "Completed algorithm $alg_name (vertex $vertex_id) on thread $(threadid())"
-
-        # Store the result in the algorithm vertex
-        put_result!(event, vertex_id, result)
-
-        # Also store in all connected data vertices (algorithm outputs)
-        for data_vertex in outneighbors(graph, vertex_id)
-            if !(data_vertex in algo_vertices)
-                put_result!(event, data_vertex, result)
-            end
-        end
-
+    while algs_in_flight > 0
+        vertex_id, results = take!(done_channel)
+        result_vertices = outneighbors(event.data_flow.graph, vertex_id)
+        put_results!(event, result_vertices, results)
+        algs_in_flight -= 1
         # Check algorithm children to see if they're ready
-        for child in children[vertex_id]
-            parent_count[child] -= 1
-            if parent_count[child] == 0
-                spawn_vertex(child)
-                active += 1
+        for child in get_prop(event.data_flow.graph, vertex_id, :successor_algs)
+            count = deps[child] -= 1
+            if count == 0
+                schedule_algorithm(event, child, coefficients, done_channel)
+                algs_in_flight += 1
             end
         end
     end

--- a/src/scheduling.jl
+++ b/src/scheduling.jl
@@ -39,6 +39,7 @@ struct DataFlowGraph
         alg_vertices = MetaGraphs.filter_vertices(graph, :type, "Algorithm")
         sorted_vertices = MetaGraphs.topological_sort(graph)
         sorted_alg_vertices = intersect(sorted_vertices, alg_vertices)
+
         # cache number of algorithm dependencies for each algorithms
         # and indices of dependant algorithms
         for v in sorted_alg_vertices
@@ -49,12 +50,13 @@ struct DataFlowGraph
             for data_successor in outneighbors(graph, v)
                 successors = outneighbors(graph, data_successor)
                 append!(successor_algs, successors)
-                for alg in successors
-                    deps = get_prop(graph, alg, :deps)
-                    set_prop!(graph, alg, :deps, deps + 1)
-                end
             end
+            unique!(successor_algs) # remove duplicates - algorithms consuming multiple objects produced by the the same algorithms
             set_prop!(graph, v, :successor_algs, successor_algs)
+            for alg in successor_algs
+                deps = get_prop(graph, alg, :deps)
+                set_prop!(graph, alg, :deps, deps + 1)
+            end
         end
         new(graph, sorted_alg_vertices)
     end

--- a/test/scheduling.jl
+++ b/test/scheduling.jl
@@ -13,6 +13,45 @@ using Logging
     is_fast = "no-fast" ∉ ARGS
     coefficients = FrameworkDemo.calibrate_crunch(; fast = is_fast)
 
+    df = FrameworkDemo.mockup_dataflow(graph)
+    event = FrameworkDemo.Event(df)
+
+    test_logger = TestLogger()
+    with_logger(test_logger) do
+        FrameworkDemo.schedule_graph!(event, coefficients)
+    end
+    @testset "Timeline" begin
+        # store order of appearance in the log by message
+        log_position = Dict{String, Int}()
+        for (i, record) in enumerate(test_logger.logs)
+            # match name from message "Executing $name $event_number" logged by mockup algs
+            m = match(r"Executing (\w+)", record.message)
+            if m !== nothing
+                component = m.captures[1]
+                log_position[component] = i
+            end
+        end
+
+        @test log_position["ProducerA"] < log_position["TransformerAB"]
+        @test log_position["ProducerBC"] < log_position["TransformerAB"]
+        @test log_position["ProducerBC"] < log_position["ConsumerBC"]
+        @test log_position["ProducerBC"] < log_position["TransformerC"]
+        @test log_position["ProducerBC"] < log_position["ConsumerCD"]
+        @test log_position["TransformerAB"] < log_position["ConsumerE"]
+        @test log_position["TransformerAB"] < log_position["ConsumerCD"]
+    end
+
+    @testset "Dependencies" begin
+        get_id(name) = graph[name, :node_id]
+        get_parent(name) = FrameworkDemo.get_result(event, graph[name, :node_id])
+        @test get_parent("a") == get_id("ProducerA")
+        @test get_parent("b") == get_id("ProducerBC")
+        @test get_parent("c") == get_id("ProducerBC")
+        @test get_parent("d") == get_id("TransformerAB")
+        @test get_parent("e") == get_id("TransformerAB")
+        @test get_parent("f") == get_id("TransformerAB")
+        @test get_parent("g") == get_id("TransformerC")
+    end
     @testset "Pipeline" begin
         event_count = 5
         data_flow = FrameworkDemo.mockup_dataflow(graph)

--- a/test/scheduling.jl
+++ b/test/scheduling.jl
@@ -7,8 +7,6 @@ using Logging
 @testset "Scheduling" begin
     path = joinpath(pkgdir(FrameworkDemo), "data/demo/datadeps/df.graphml")
     graph = FrameworkDemo.parse_graphml(path)
-    ilength(x) = sum(_ -> 1, x) # no standard length for MetaGraphs.filter_vertices iterator
-    algorithms_count = ilength(MetaGraphs.filter_vertices(graph, :type, "Algorithm"))
     set_indexing_prop!(graph, :node_id)
     is_fast = "no-fast" ∉ ARGS
     coefficients = FrameworkDemo.calibrate_crunch(; fast = is_fast)
@@ -16,10 +14,35 @@ using Logging
     df = FrameworkDemo.mockup_dataflow(graph)
     event = FrameworkDemo.Event(df)
 
+    @testset "Dependencies" begin
+        get_dependency_count(name) = get_prop(df.graph, df.graph[name, :node_id], :deps)
+        @test get_dependency_count("ProducerA") == 0
+        @test get_dependency_count("ProducerBC") == 0
+        @test get_dependency_count("TransformerAB") == 2
+        @test get_dependency_count("ConsumerBC") == 1
+        @test get_dependency_count("TransformerC") == 1
+        @test get_dependency_count("ConsumerCD") == 2
+        @test get_dependency_count("ConsumerE") == 1
+    end
+
+    @testset "Successor Algorithms" begin
+        get_id(name) = df.graph[name, :node_id]
+        get_successors(name) = get_prop(df.graph, get_id(name), :successor_algs) |> sort
+        normalize(vec) = vec .|> get_id |> sort
+        @test get_successors("ProducerA") == normalize(["TransformerAB"])
+        @test get_successors("ProducerBC") ==
+              normalize(["TransformerAB", "ConsumerBC", "TransformerC", "ConsumerCD"])
+        @test get_successors("TransformerAB") == normalize(["ConsumerE", "ConsumerCD"])
+        @test isempty(get_successors("ConsumerBC"))
+        @test isempty(get_successors("TransformerC"))
+        @test isempty(get_successors("ConsumerCD"))
+    end
+
     test_logger = TestLogger()
     with_logger(test_logger) do
         FrameworkDemo.schedule_graph!(event, coefficients)
     end
+
     @testset "Timeline" begin
         # store order of appearance in the log by message
         log_position = Dict{String, Int}()
@@ -31,7 +54,7 @@ using Logging
                 log_position[component] = i
             end
         end
-
+        # Algorithm should appear in the log before its successors
         @test log_position["ProducerA"] < log_position["TransformerAB"]
         @test log_position["ProducerBC"] < log_position["TransformerAB"]
         @test log_position["ProducerBC"] < log_position["ConsumerBC"]
@@ -41,9 +64,10 @@ using Logging
         @test log_position["TransformerAB"] < log_position["ConsumerCD"]
     end
 
-    @testset "Dependencies" begin
-        get_id(name) = graph[name, :node_id]
-        get_parent(name) = FrameworkDemo.get_result(event, graph[name, :node_id])
+    @testset "Results" begin
+        get_id(name) = event.data_flow.graph[name, :node_id]
+        get_parent(name) = FrameworkDemo.get_result(event, get_id(name))
+        # mockup algorithms put their id in the store for data objects they produce
         @test get_parent("a") == get_id("ProducerA")
         @test get_parent("b") == get_id("ProducerBC")
         @test get_parent("c") == get_id("ProducerBC")
@@ -52,6 +76,7 @@ using Logging
         @test get_parent("f") == get_id("TransformerAB")
         @test get_parent("g") == get_id("TransformerC")
     end
+
     @testset "Pipeline" begin
         event_count = 5
         data_flow = FrameworkDemo.mockup_dataflow(graph)


### PR DESCRIPTION
BEGINRELEASENOTES
- Cache dependencies and information about dependent algorithms since they are the same for each event
- Replace `missing` with `nothing` for non-existent crunching coefficients
- Mockup algorithms return their IDs

ENDRELEASENOTES

This is a follow up to #87 to make the logic a bit simpler

Since algorithm dependencies are a property of the graph, they are the same for each event and could be reused. I propose to store them in the graph while assembling the data-flow.

The mockup algorithms are changed to return a vector filled with their IDs which then get put into the store, so for testing each data object can be associated with the algorithm that produced it.

Also bringing back scheduling test after rework not to relay on Dagger

Also changed indicating that there are no crunching coefficients with `nothing` instead of `missing`. Other parts of the code were already using `nothing` for this purpose but in scheduling we were changing it to `missing` for no good reason