### PR TITLE
remove redundant main for juliac

### DIFF
--- a/bin/schedule.jl
+++ b/bin/schedule.jl
@@ -263,9 +263,3 @@ function (@main)(raw_args)
     end
     return 0
 end
-
-# Entrypoint for juliac
-Base.@ccallable function main(argc::Cint, argv::Ptr{Ptr{Cchar}})::Cint
-    args = [unsafe_string(unsafe_load(argv, i)) for i in 2:argc]
-    return main(args)
-end


### PR DESCRIPTION
BEGINRELEASENOTES
- Removed extra main for juliac. Since 1.12.0-rc2 it's redundant as juliac can now directly use the standard `@main`.

ENDRELEASENOTES
